### PR TITLE
Fix OAuth registration endpoint for MCP spec compliance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -648,6 +648,11 @@ app.post('/mcp/register', async (c) => {
 	return handleRegister(c.req.raw, c.env);
 });
 
+// Also handle /register for MCP spec compliance
+app.post('/register', async (c) => {
+	return handleRegister(c.req.raw, c.env);
+});
+
 // Helper to create 401 response with proper WWW-Authenticate header for MCP OAuth
 function unauthorizedResponse(c: { req: { url: string } }, error: string, description: string): Response {
 	const url = new URL(c.req.url);

--- a/src/oauth-handler.ts
+++ b/src/oauth-handler.ts
@@ -29,7 +29,7 @@ export function handleOAuthDiscovery(url: URL): Response {
 		issuer: url.origin,
 		authorization_endpoint: `${url.origin}/mcp/authorize`,
 		token_endpoint: `${url.origin}/mcp/token`,
-		registration_endpoint: `${url.origin}/mcp/register`,
+		registration_endpoint: `${url.origin}/register`,
 		scopes_supported: ['mcp:read', 'mcp:write'],
 		response_types_supported: ['code'],
 		response_modes_supported: ['query'],


### PR DESCRIPTION
## Summary
Fixes MCP client compatibility issues with dynamic client registration.

## Changes
- Add `/register` route in addition to `/mcp/register`
- Update OAuth discovery to advertise `/register` endpoint

## Problem
MCP clients (like MCP Inspector) were hitting `/register` directly but the server only had `/mcp/register`, causing 404 errors during OAuth flow.

## Testing
After deploying, the OAuth discovery at `/.well-known/oauth-authorization-server` will advertise the correct `/register` endpoint.