### PR TITLE
Add markdown body support to email tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ A remote MCP (Model Context Protocol) server for Fastmail email, contacts, and c
 - `flag_email` - Flag or unflag an email
 - `bulk_flag` - Flag or unflag multiple emails
 
+### Email Body Formats
+
+The `send_email`, `create_draft`, and `reply_to_email` tools support three body formats:
+
+| Parameter | Format | Description |
+|-----------|--------|-------------|
+| `textBody` | Plain text | Simple text content |
+| `htmlBody` | HTML | Rich HTML content |
+| `markdownBody` | Markdown | GitHub-flavored Markdown (auto-converted to HTML) |
+
+At least one body format is required. If `markdownBody` is provided, it takes precedence over `htmlBody`.
+
+**Example with Markdown:**
+```json
+{
+  "to": ["recipient@example.com"],
+  "subject": "Meeting notes",
+  "markdownBody": "# Meeting Summary\n\n- Point 1\n- Point 2\n\n**Action items:**\n1. Review proposal\n2. Send feedback"
+}
+```
+
 ### Sending Emails with Attachments
 
 Both `send_email` and `create_draft` support file attachments. Attachments are passed as an array of objects with base64-encoded content:
@@ -84,6 +105,7 @@ The `reply_to_email` tool provides a convenient way to reply to emails with prop
 | `emailId` | string | required | ID of the email to reply to |
 | `body` | string | required | Your reply message (plain text) |
 | `htmlBody` | string | optional | Your reply message (HTML) |
+| `markdownBody` | string | optional | Your reply message (Markdown, auto-converted to HTML) |
 | `replyAll` | boolean | `false` | Reply to all recipients (sender + CC) |
 | `sendImmediately` | boolean | `false` | Send immediately vs create draft |
 | `excludeQuote` | boolean | `false` | Skip quoting the original message |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
 	"name": "fastmail-mcp-remote",
-	"version": "1.2.0",
+	"version": "1.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "fastmail-mcp-remote",
-			"version": "1.2.0",
+			"version": "1.6.0",
 			"dependencies": {
 				"agents": "^0.3.6",
 				"hono": "^4.11.3",
 				"just-pick": "^4.2.0",
+				"marked": "^17.0.1",
 				"zod": "^4.2.1"
 			},
 			"devDependencies": {
@@ -20,52 +21,6 @@
 				"typescript": "5.9.3",
 				"vitest": "^4.0.18",
 				"wrangler": "^4.59.1"
-			}
-		},
-		"node_modules/@ai-sdk/gateway": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.2.tgz",
-			"integrity": "sha512-giJEg9ob45htbu3iautK+2kvplY2JnTj7ir4wZzYSQWvqGatWfBBfDuNCU5wSJt9BCGjymM5ZS9ziD42JGCZBw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "3.0.0",
-				"@ai-sdk/provider-utils": "4.0.1",
-				"@vercel/oidc": "3.0.5"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
-		"node_modules/@ai-sdk/provider": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.0.tgz",
-			"integrity": "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"json-schema": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@ai-sdk/provider-utils": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.1.tgz",
-			"integrity": "sha512-de2v8gH9zj47tRI38oSxhQIewmNc+OZjYIOOaMoVWKL65ERSav2PYYZHPSPCrfOeLMkv+Dyh8Y0QGwkO29wMWQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "3.0.0",
-				"@standard-schema/spec": "^1.1.0",
-				"eventsource-parser": "^3.0.6"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/@apidevtools/json-schema-ref-parser": {
@@ -110,36 +65,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
 			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@cloudflare/ai-chat": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.0.4.tgz",
-			"integrity": "sha512-NGQRt34X/UI+mx9fss7LmTTNBDVlFrtu+7JFoaykLUI738w9gjDplsMbOenCRbSr7UW4ngHGnv3YWUmV99eEnQ==",
-			"license": "MIT",
-			"peer": true,
-			"peerDependencies": {
-				"agents": "^0.3.4",
-				"ai": "^6.0.0",
-				"react": "^19.0.0",
-				"zod": "^3.25.0 || ^4.0.0"
-			}
-		},
-		"node_modules/@cloudflare/codemode": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/codemode/-/codemode-0.0.5.tgz",
-			"integrity": "sha512-00KNtk0tJBkhJ+DdfDqCqWNDyQ9O3pGOrMZSutXF0MQDCjFIjLO3ZDZ5c4FlMmhsysvcj8TyJYzetaJAY4H+cA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"zod-to-ts": "^2.0.0"
-			},
-			"peerDependencies": {
-				"agents": "^0.3.6",
-				"ai": "^6.0.0",
-				"zod": "^3.25.0 || ^4.0.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
 			"version": "0.4.2",
@@ -280,13 +206,6 @@
 			"engines": {
 				"node": ">=16"
 			}
-		},
-		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260127.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260127.0.tgz",
-			"integrity": "sha512-4M1HLcWViSdT/pAeDGEB5x5P3sqW7UIi34QrBRnxXbqjAY9if8vBU/lWRWnM+UqKzxWGB2LYjEVOzZrp0jZL+w==",
-			"license": "MIT OR Apache-2.0",
-			"peer": true
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -1329,15 +1248,6 @@
 				}
 			}
 		},
-		"node_modules/@opentelemetry/api": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/@poppinss/colors": {
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -1741,6 +1651,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/chai": {
@@ -1786,18 +1697,8 @@
 			"integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
-			}
-		},
-		"node_modules/@vercel/oidc": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
-			"integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">= 20"
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -1882,72 +1783,12 @@
 				}
 			}
 		},
-		"node_modules/@vitest/pretty-format": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tinyrainbow": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/runner": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@vitest/utils": "3.2.4",
-				"pathe": "^2.0.3",
-				"strip-literal": "^3.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/snapshot": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@vitest/pretty-format": "3.2.4",
-				"magic-string": "^0.30.17",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
 		"node_modules/@vitest/spy": {
 			"version": "4.0.18",
 			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
 			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
 			"dev": true,
 			"license": "MIT",
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/utils": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "3.2.4",
-				"loupe": "^3.1.4",
-				"tinyrainbow": "^2.0.0"
-			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
@@ -1970,7 +1811,6 @@
 			"resolved": "https://registry.npmjs.org/agents/-/agents-0.3.6.tgz",
 			"integrity": "sha512-gJtXDGV2jhPI/WzZOYAM5GJleOq7U2o7fnenE89RJ3Y5klm29O1Pk4sQoLVASO2sTucPNtJRMztQCGL2352B+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cfworker/json-schema": "^4.1.1",
 				"@modelcontextprotocol/sdk": "1.25.2",
@@ -2010,25 +1850,6 @@
 				"x402": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/ai": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.3.tgz",
-			"integrity": "sha512-OOo+/C+sEyscoLnbY3w42vjQDICioVNyS+F+ogwq6O5RJL/vgWGuiLzFwuP7oHTeni/MkmX8tIge48GTdaV7QQ==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@ai-sdk/gateway": "3.0.2",
-				"@ai-sdk/provider": "3.0.0",
-				"@ai-sdk/provider-utils": "4.0.1",
-				"@opentelemetry/api": "1.9.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/ajv": {
@@ -2531,7 +2352,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -2786,7 +2606,6 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
 			"integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -2890,13 +2709,6 @@
 			"integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/js-tokens": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/js-yaml": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2972,13 +2784,6 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"license": "MIT"
 		},
-		"node_modules/loupe": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2987,6 +2792,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "17.0.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+			"integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -3276,7 +3093,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3406,16 +3222,6 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/react": {
-			"version": "19.2.3",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-			"integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/require-from-string": {
@@ -3768,19 +3574,6 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/strip-literal": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"js-tokens": "^9.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
 		"node_modules/supports-color": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -3827,16 +3620,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/tinyrainbow": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3872,8 +3655,8 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3905,7 +3688,6 @@
 			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"pathe": "^2.0.3"
 			}
@@ -3934,7 +3716,6 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -4187,7 +3968,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -4368,7 +4148,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
 			"integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -4380,16 +4159,6 @@
 			"license": "ISC",
 			"peerDependencies": {
 				"zod": "^3.25 || ^4"
-			}
-		},
-		"node_modules/zod-to-ts": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-2.0.0.tgz",
-			"integrity": "sha512-aHsUgIl+CQutKAxtRNeZslLCLXoeuSq+j5HU7q3kvi/c2KIAo6q4YjT7/lwFfACxLB923ELHYMkHmlxiqFy4lw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"typescript": "^5.0.0",
-				"zod": "^3.25.0 || ^4.0.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fastmail-mcp-remote",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "Remote MCP server for Fastmail on Cloudflare Workers with GitHub OAuth",
 	"private": true,
 	"scripts": {
@@ -16,6 +16,7 @@
 		"agents": "^0.3.6",
 		"hono": "^4.11.3",
 		"just-pick": "^4.2.0",
+		"marked": "^17.0.1",
 		"zod": "^4.2.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

- Add `markdownBody` parameter to `send_email`, `create_draft`, and `reply_to_email` tools
- Markdown is automatically converted to HTML using the [marked](https://github.com/markedjs/marked) library
- If both `markdownBody` and `htmlBody` are provided, `markdownBody` takes precedence

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Add `markdownBody` param to all three tools, import marked |
| `package.json` | Add marked dependency, bump to v1.6.0 |
| `README.md` | Document new body format options |

## Example Usage

```json
{
  "to": ["recipient@example.com"],
  "subject": "Meeting notes",
  "markdownBody": "# Meeting Summary\n\n- Point 1\n- Point 2\n\n**Action items:**\n1. Review proposal\n2. Send feedback"
}
```

## Test plan

- [x] TypeScript type check passes
- [x] All existing tests pass
- [ ] Manual test: Create draft with markdown body
- [ ] Manual test: Send email with markdown body
- [ ] Manual test: Reply with markdown body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces user-provided Markdown-to-HTML conversion via `marked`, which can affect email rendering and has potential HTML injection considerations if the downstream mail client doesn’t sanitize.
> 
> **Overview**
> Adds a new `markdownBody` input to `send_email`, `create_draft`, and `reply_to_email`, automatically converting Markdown to HTML (and preferring it over `htmlBody`) before sending/creating the message.
> 
> Updates validation/error messaging to require at least one of `textBody`, `htmlBody`, or `markdownBody`, adds the `marked` dependency, bumps the package version to `1.6.0`, and documents the new body-format behavior in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67b335c8d816693dba83559714a7eb1b89e17333. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->