### PR TITLE
Add role-based delegate permissions for MCP tools

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -14,13 +14,17 @@ If a file contains what appears to be a personal username in a path (e.g., `/Use
 
 ## Email Address Detection
 
-If a file contains an email address pattern (except @example.com, @anthropic.com, or @noreply addresses), then:
+If a configuration file (wrangler.jsonc, wrangler.toml, *.d.ts, .env*, *.json) contains a real email address (not @example.com, @anthropic.com, @noreply, or @users.noreply.github.com), then:
+- Add a **blocking** bug: "Real email address detected in configuration file. Move to a secret or environment variable to avoid committing PII to the repo. Use `wrangler secret put` for Cloudflare Workers."
+
+If any other file contains an email address pattern (except @example.com, @anthropic.com, or @noreply addresses), then:
 - Add a non-blocking bug: "Email address detected. Verify this is not personal information that should be parameterized or removed."
 
 Exclude from email checks:
 - CHANGELOG.md
 - package-lock.json
 - node_modules/
+- Co-Authored-By lines in commit messages
 
 ## API Keys and Secrets
 

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -3,6 +3,9 @@ ACCESS_CLIENT_ID=<your cloudflare access client id>
 ACCESS_CLIENT_SECRET=<your cloudflare access client secret>
 ACCESS_TEAM_NAME=<your cloudflare zero trust team name>
 
+# Allowed users (comma-separated email addresses)
+ALLOWED_USERS=user@example.com
+
 # Fastmail API token (get from https://www.fastmail.com/settings/security/tokens)
 FASTMAIL_API_TOKEN=<your fastmail api token>
 

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,368 @@
+/**
+ * Role-based delegate permissions for MCP tools.
+ *
+ * Enforces two layers of access control:
+ *   1. Role-based: admin (full access) vs delegate (read + inbox management + drafts)
+ *   2. Category-based: per-user disabled categories (e.g., hide calendar/contacts)
+ *
+ * Config is stored in KV under "config:permissions" and cached for 5 minutes.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type Role = 'admin' | 'delegate';
+
+export type ToolCategory =
+	| 'EMAIL_READ'
+	| 'CONTACTS'
+	| 'CALENDAR_READ'
+	| 'CALENDAR_WRITE'
+	| 'INBOX_MANAGE'
+	| 'DRAFT'
+	| 'REPLY'
+	| 'SEND'
+	| 'META';
+
+export interface UserConfig {
+	role: Role;
+	disabled_categories: ToolCategory[];
+}
+
+export interface PermissionsConfig {
+	users: Record<string, UserConfig>;
+	default_role: Role;
+	default_disabled_categories: ToolCategory[];
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Map every MCP tool name to its category. */
+export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
+	// EMAIL_READ
+	list_mailboxes: 'EMAIL_READ',
+	list_emails: 'EMAIL_READ',
+	get_email: 'EMAIL_READ',
+	search_emails: 'EMAIL_READ',
+	get_recent_emails: 'EMAIL_READ',
+	get_email_attachments: 'EMAIL_READ',
+	download_attachment: 'EMAIL_READ',
+	advanced_search: 'EMAIL_READ',
+	get_thread: 'EMAIL_READ',
+	get_mailbox_stats: 'EMAIL_READ',
+	get_account_summary: 'EMAIL_READ',
+	list_identities: 'EMAIL_READ',
+
+	// CONTACTS
+	list_contacts: 'CONTACTS',
+	get_contact: 'CONTACTS',
+	search_contacts: 'CONTACTS',
+
+	// CALENDAR_READ
+	list_calendars: 'CALENDAR_READ',
+	list_calendar_events: 'CALENDAR_READ',
+	get_calendar_event: 'CALENDAR_READ',
+
+	// CALENDAR_WRITE
+	create_calendar_event: 'CALENDAR_WRITE',
+
+	// INBOX_MANAGE
+	mark_email_read: 'INBOX_MANAGE',
+	flag_email: 'INBOX_MANAGE',
+	delete_email: 'INBOX_MANAGE',
+	move_email: 'INBOX_MANAGE',
+	bulk_mark_read: 'INBOX_MANAGE',
+	bulk_move: 'INBOX_MANAGE',
+	bulk_delete: 'INBOX_MANAGE',
+	bulk_flag: 'INBOX_MANAGE',
+
+	// DRAFT
+	create_draft: 'DRAFT',
+
+	// REPLY (dual behavior — checked specially for sendImmediately)
+	reply_to_email: 'REPLY',
+
+	// SEND
+	send_email: 'SEND',
+
+	// META
+	check_function_availability: 'META',
+};
+
+/** Categories that a delegate role is allowed to use. */
+const DELEGATE_ALLOWED_CATEGORIES: Set<ToolCategory> = new Set([
+	'EMAIL_READ',
+	'CONTACTS',
+	'CALENDAR_READ',
+	'INBOX_MANAGE',
+	'DRAFT',
+	'REPLY',
+	'META',
+]);
+
+/** Actionable error hints for denied tools. */
+const DENIAL_HINTS: Record<string, string> = {
+	send_email: "Use 'create_draft' to compose emails as drafts instead.",
+	create_calendar_event: 'Calendar write access is not available for delegate accounts.',
+	reply_to_email: "Use 'reply_to_email' without sendImmediately:true to create a draft reply instead.",
+};
+
+// ─── KV Cache ───────────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+let cachedConfig: PermissionsConfig | null = null;
+let cachedAt = 0;
+
+const DEFAULT_CONFIG: PermissionsConfig = {
+	users: {},
+	default_role: 'admin',
+	default_disabled_categories: [],
+};
+
+/** Load permissions config from KV with 5-minute module-level cache. */
+export async function getPermissionsConfig(kv: KVNamespace): Promise<PermissionsConfig> {
+	const now = Date.now();
+	if (cachedConfig && now - cachedAt < CACHE_TTL_MS) {
+		return cachedConfig;
+	}
+
+	const data = await kv.get<PermissionsConfig>('config:permissions', 'json');
+	cachedConfig = data ?? DEFAULT_CONFIG;
+	cachedAt = now;
+	return cachedConfig;
+}
+
+/** Exposed for testing — resets the module-level cache. */
+export function _resetCache(): void {
+	cachedConfig = null;
+	cachedAt = 0;
+}
+
+// ─── User Config ────────────────────────────────────────────────────────────
+
+/** Resolve a user's config. Case-insensitive email lookup; falls back to defaults. */
+export function getUserConfig(config: PermissionsConfig, email: string): UserConfig {
+	const normalized = email.toLowerCase();
+	// Config keys may be any case — normalize for lookup
+	for (const [key, value] of Object.entries(config.users)) {
+		if (key.toLowerCase() === normalized) {
+			return value;
+		}
+	}
+	return {
+		role: config.default_role,
+		disabled_categories: config.default_disabled_categories,
+	};
+}
+
+// ─── Permission Checks ─────────────────────────────────────────────────────
+
+export interface PermissionResult {
+	allowed: boolean;
+	error?: string;
+}
+
+/**
+ * Check if a specific tool call is allowed for a user.
+ *
+ * Checks both:
+ *   1. disabled_categories — tool's category is explicitly disabled for this user
+ *   2. role-based denial — delegate can't use SEND or CALENDAR_WRITE
+ *
+ * Special case: reply_to_email with sendImmediately:true is denied for delegates.
+ */
+export function isToolAllowed(
+	userConfig: UserConfig,
+	toolName: string,
+	args?: Record<string, unknown>,
+): PermissionResult {
+	const category = TOOL_CATEGORIES[toolName];
+	if (!category) {
+		// Unknown tool — allow (could be a new tool not yet categorized)
+		return { allowed: true };
+	}
+
+	// Check disabled categories first (applies to ALL roles)
+	if (userConfig.disabled_categories.includes(category)) {
+		return {
+			allowed: false,
+			error: `Permission denied: '${toolName}' is disabled for your account (category: ${category}).`,
+		};
+	}
+
+	// Admin bypasses role checks
+	if (userConfig.role === 'admin') {
+		return { allowed: true };
+	}
+
+	// Delegate role checks
+	if (!DELEGATE_ALLOWED_CATEGORIES.has(category)) {
+		const hint = DENIAL_HINTS[toolName] || '';
+		return {
+			allowed: false,
+			error: `Permission denied: '${toolName}' is not available for delegate accounts.${hint ? ` ${hint}` : ''}`,
+		};
+	}
+
+	// Special case: reply_to_email with sendImmediately:true
+	if (toolName === 'reply_to_email' && args?.sendImmediately === true) {
+		return {
+			allowed: false,
+			error: `Permission denied: '${toolName}' with sendImmediately:true is not available for delegate accounts. ${DENIAL_HINTS.reply_to_email}`,
+		};
+	}
+
+	return { allowed: true };
+}
+
+/**
+ * Return the set of tool names visible to a user (for tools/list filtering).
+ * Excludes tools whose category is disabled OR denied by role.
+ */
+export function getVisibleTools(userConfig: UserConfig): Set<string> {
+	const visible = new Set<string>();
+	for (const [toolName, category] of Object.entries(TOOL_CATEGORIES)) {
+		// Skip disabled categories
+		if (userConfig.disabled_categories.includes(category)) continue;
+
+		// Skip role-denied categories for delegate
+		if (userConfig.role === 'delegate' && !DELEGATE_ALLOWED_CATEGORIES.has(category)) continue;
+
+		visible.add(toolName);
+	}
+	return visible;
+}
+
+// ─── Hono-Level Interception ────────────────────────────────────────────────
+
+/**
+ * Check a tools/call request and return a JSON-RPC error Response if denied.
+ * Returns null if the request is allowed (or is not a tools/call).
+ *
+ * Clones the request internally so the original body remains unconsumed.
+ */
+export async function checkMcpPermissions(
+	request: Request,
+	userLogin: string,
+	kv: KVNamespace,
+): Promise<Response | null> {
+	// Only intercept POST requests (JSON-RPC)
+	if (request.method !== 'POST') return null;
+
+	let body: unknown;
+	try {
+		body = await request.clone().json();
+	} catch {
+		// Not JSON — let it through
+		return null;
+	}
+
+	// JSON-RPC can be an object or an array (batch)
+	const messages = Array.isArray(body) ? body : [body];
+
+	const config = await getPermissionsConfig(kv);
+	const userConfig = getUserConfig(config, userLogin);
+
+	for (const msg of messages) {
+		if (
+			typeof msg !== 'object' ||
+			msg === null ||
+			(msg as Record<string, unknown>).method !== 'tools/call'
+		) {
+			continue;
+		}
+
+		const params = (msg as Record<string, unknown>).params as Record<string, unknown> | undefined;
+		const toolName = params?.name as string | undefined;
+		if (!toolName) continue;
+
+		const args = params?.arguments as Record<string, unknown> | undefined;
+		const result = isToolAllowed(userConfig, toolName, args);
+
+		if (!result.allowed) {
+			const id = (msg as Record<string, unknown>).id ?? null;
+			return new Response(
+				JSON.stringify({
+					jsonrpc: '2.0',
+					id,
+					error: {
+						code: -32600,
+						message: result.error,
+					},
+				}),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			);
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Filter a tools/list response to hide tools from disabled/denied categories.
+ * If the response is not a tools/list result, passes through unchanged.
+ */
+export async function filterToolsListResponse(
+	response: Response,
+	userLogin: string,
+	kv: KVNamespace,
+): Promise<Response> {
+	// Only filter JSON responses
+	const contentType = response.headers.get('content-type') || '';
+	if (!contentType.includes('application/json')) return response;
+
+	let body: unknown;
+	try {
+		body = await response.clone().json();
+	} catch {
+		return response;
+	}
+
+	// Check if this is a tools/list result (has result.tools array)
+	if (
+		typeof body !== 'object' ||
+		body === null ||
+		!('result' in (body as Record<string, unknown>))
+	) {
+		return response;
+	}
+
+	const result = (body as Record<string, unknown>).result as Record<string, unknown> | undefined;
+	if (!result || !Array.isArray(result.tools)) return response;
+
+	const config = await getPermissionsConfig(kv);
+	const userConfig = getUserConfig(config, userLogin);
+	const visible = getVisibleTools(userConfig);
+
+	// Filter tools
+	const filteredTools = (result.tools as Array<Record<string, unknown>>).filter(
+		(tool) => {
+			const name = tool.name as string;
+			// Allow tools not in our category map (future tools)
+			return !TOOL_CATEGORIES[name] || visible.has(name);
+		},
+	);
+
+	// Reconstruct response with filtered tools
+	const filteredBody = {
+		...(body as Record<string, unknown>),
+		result: {
+			...result,
+			tools: filteredTools,
+		},
+	};
+
+	// Copy headers but remove Content-Length so the runtime recomputes it
+	// for the new (shorter) body. Passing stale Content-Length would cause
+	// clients to hang waiting for bytes that never arrive.
+	const headers = new Headers(response.headers);
+	headers.delete('Content-Length');
+
+	return new Response(JSON.stringify(filteredBody), {
+		status: response.status,
+		headers,
+	});
+}

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	type PermissionsConfig,
+	type UserConfig,
+	getUserConfig,
+	isToolAllowed,
+	getVisibleTools,
+	TOOL_CATEGORIES,
+	_resetCache,
+} from '../src/permissions';
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const TEST_CONFIG: PermissionsConfig = {
+	users: {
+		'admin@example.com': {
+			role: 'admin',
+			disabled_categories: ['CONTACTS', 'CALENDAR_READ', 'CALENDAR_WRITE'],
+		},
+		'delegate@example.com': {
+			role: 'delegate',
+			disabled_categories: ['CONTACTS', 'CALENDAR_READ', 'CALENDAR_WRITE'],
+		},
+	},
+	default_role: 'admin',
+	default_disabled_categories: [],
+};
+
+function adminConfig(): UserConfig {
+	return getUserConfig(TEST_CONFIG, 'admin@example.com');
+}
+
+function delegateConfig(): UserConfig {
+	return getUserConfig(TEST_CONFIG, 'delegate@example.com');
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	_resetCache();
+});
+
+describe('getUserConfig', () => {
+	it('returns config for known user', () => {
+		const config = getUserConfig(TEST_CONFIG, 'admin@example.com');
+		expect(config.role).toBe('admin');
+		expect(config.disabled_categories).toContain('CONTACTS');
+	});
+
+	it('is case-insensitive', () => {
+		const config = getUserConfig(TEST_CONFIG, 'ADMIN@EXAMPLE.COM');
+		expect(config.role).toBe('admin');
+	});
+
+	it('returns defaults for unknown user', () => {
+		const config = getUserConfig(TEST_CONFIG, 'unknown@example.com');
+		expect(config.role).toBe('admin');
+		expect(config.disabled_categories).toEqual([]);
+	});
+
+	it('returns custom defaults when configured', () => {
+		const custom: PermissionsConfig = {
+			...TEST_CONFIG,
+			default_role: 'delegate',
+			default_disabled_categories: ['CALENDAR_WRITE'],
+		};
+		const config = getUserConfig(custom, 'unknown@example.com');
+		expect(config.role).toBe('delegate');
+		expect(config.disabled_categories).toContain('CALENDAR_WRITE');
+	});
+});
+
+describe('isToolAllowed — admin', () => {
+	it('allows all email read tools', () => {
+		const config = adminConfig();
+		expect(isToolAllowed(config, 'list_mailboxes').allowed).toBe(true);
+		expect(isToolAllowed(config, 'get_email').allowed).toBe(true);
+		expect(isToolAllowed(config, 'advanced_search').allowed).toBe(true);
+	});
+
+	it('allows send_email', () => {
+		expect(isToolAllowed(adminConfig(), 'send_email').allowed).toBe(true);
+	});
+
+	it('allows reply_to_email with sendImmediately:true', () => {
+		expect(
+			isToolAllowed(adminConfig(), 'reply_to_email', { sendImmediately: true }).allowed,
+		).toBe(true);
+	});
+
+	it('denies tools in disabled categories', () => {
+		const result = isToolAllowed(adminConfig(), 'list_contacts');
+		expect(result.allowed).toBe(false);
+		expect(result.error).toContain('disabled');
+		expect(result.error).toContain('CONTACTS');
+	});
+
+	it('denies calendar read for admin with disabled CALENDAR_READ', () => {
+		const result = isToolAllowed(adminConfig(), 'list_calendars');
+		expect(result.allowed).toBe(false);
+	});
+
+	it('denies calendar write for admin with disabled CALENDAR_WRITE', () => {
+		const result = isToolAllowed(adminConfig(), 'create_calendar_event');
+		expect(result.allowed).toBe(false);
+	});
+});
+
+describe('isToolAllowed — delegate', () => {
+	it('allows email read tools', () => {
+		const config = delegateConfig();
+		expect(isToolAllowed(config, 'list_mailboxes').allowed).toBe(true);
+		expect(isToolAllowed(config, 'get_email').allowed).toBe(true);
+		expect(isToolAllowed(config, 'search_emails').allowed).toBe(true);
+		expect(isToolAllowed(config, 'get_thread').allowed).toBe(true);
+	});
+
+	it('allows inbox management tools', () => {
+		const config = delegateConfig();
+		expect(isToolAllowed(config, 'mark_email_read').allowed).toBe(true);
+		expect(isToolAllowed(config, 'move_email').allowed).toBe(true);
+		expect(isToolAllowed(config, 'delete_email').allowed).toBe(true);
+		expect(isToolAllowed(config, 'bulk_move').allowed).toBe(true);
+	});
+
+	it('allows create_draft', () => {
+		expect(isToolAllowed(delegateConfig(), 'create_draft').allowed).toBe(true);
+	});
+
+	it('allows reply_to_email with default args (creates draft)', () => {
+		expect(isToolAllowed(delegateConfig(), 'reply_to_email').allowed).toBe(true);
+		expect(
+			isToolAllowed(delegateConfig(), 'reply_to_email', { sendImmediately: false }).allowed,
+		).toBe(true);
+	});
+
+	it('denies send_email', () => {
+		const result = isToolAllowed(delegateConfig(), 'send_email');
+		expect(result.allowed).toBe(false);
+		expect(result.error).toContain('delegate');
+		expect(result.error).toContain('create_draft');
+	});
+
+	it('denies reply_to_email with sendImmediately:true', () => {
+		const result = isToolAllowed(delegateConfig(), 'reply_to_email', { sendImmediately: true });
+		expect(result.allowed).toBe(false);
+		expect(result.error).toContain('sendImmediately');
+	});
+
+	it('denies tools in disabled categories', () => {
+		const result = isToolAllowed(delegateConfig(), 'list_contacts');
+		expect(result.allowed).toBe(false);
+		expect(result.error).toContain('disabled');
+	});
+
+	it('allows check_function_availability (META)', () => {
+		expect(isToolAllowed(delegateConfig(), 'check_function_availability').allowed).toBe(true);
+	});
+
+	it('allows unknown tools (not in category map)', () => {
+		expect(isToolAllowed(delegateConfig(), 'future_new_tool').allowed).toBe(true);
+	});
+});
+
+describe('getVisibleTools', () => {
+	it('excludes disabled categories for admin', () => {
+		const visible = getVisibleTools(adminConfig());
+		// Admin with disabled CONTACTS/CALENDAR — no contact or calendar tools
+		expect(visible.has('list_contacts')).toBe(false);
+		expect(visible.has('list_calendars')).toBe(false);
+		expect(visible.has('create_calendar_event')).toBe(false);
+		// But email tools are visible
+		expect(visible.has('list_mailboxes')).toBe(true);
+		expect(visible.has('send_email')).toBe(true);
+	});
+
+	it('excludes disabled categories AND role-denied tools for delegate', () => {
+		const visible = getVisibleTools(delegateConfig());
+		// Disabled categories
+		expect(visible.has('list_contacts')).toBe(false);
+		expect(visible.has('list_calendars')).toBe(false);
+		// Role-denied
+		expect(visible.has('send_email')).toBe(false);
+		expect(visible.has('create_calendar_event')).toBe(false);
+		// Allowed
+		expect(visible.has('list_mailboxes')).toBe(true);
+		expect(visible.has('create_draft')).toBe(true);
+		expect(visible.has('reply_to_email')).toBe(true);
+	});
+
+	it('returns all tools for admin with no disabled categories', () => {
+		const config: UserConfig = { role: 'admin', disabled_categories: [] };
+		const visible = getVisibleTools(config);
+		const allTools = Object.keys(TOOL_CATEGORIES);
+		for (const tool of allTools) {
+			expect(visible.has(tool)).toBe(true);
+		}
+	});
+
+	it('returns correct count for delegate with no disabled categories', () => {
+		const config: UserConfig = { role: 'delegate', disabled_categories: [] };
+		const visible = getVisibleTools(config);
+		// Delegate should not see SEND or CALENDAR_WRITE tools
+		expect(visible.has('send_email')).toBe(false);
+		expect(visible.has('create_calendar_event')).toBe(false);
+		// But sees everything else
+		expect(visible.has('list_mailboxes')).toBe(true);
+		expect(visible.has('create_draft')).toBe(true);
+		expect(visible.has('reply_to_email')).toBe(true);
+		expect(visible.has('list_contacts')).toBe(true);
+		expect(visible.has('list_calendars')).toBe(true);
+	});
+});
+
+describe('TOOL_CATEGORIES completeness', () => {
+	it('maps all 31 tools', () => {
+		expect(Object.keys(TOOL_CATEGORIES).length).toBe(31);
+	});
+
+	it('has no empty categories', () => {
+		const categories = new Set(Object.values(TOOL_CATEGORIES));
+		expect(categories.size).toBeGreaterThanOrEqual(9);
+	});
+});

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -8,8 +8,8 @@ declare namespace Cloudflare {
 	}
 	interface Env {
 		OAUTH_KV: KVNamespace;
-		ACCESS_TEAM_NAME: "REDACTED_TEAM_NAME";
-		ALLOWED_USERS: "REDACTED_EMAIL_1";
+		ACCESS_TEAM_NAME: string;
+		ALLOWED_USERS: string;
 		ACCESS_CLIENT_ID: string;
 		ACCESS_CLIENT_SECRET: string;
 		FASTMAIL_API_TOKEN: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -79,10 +79,9 @@
 	 */
 	// Set WORKER_URL via: npx wrangler secret put WORKER_URL
 	// Value should be your deployed worker URL (e.g., https://fastmail-mcp.shahine.com)
-	"vars": {
-		"ACCESS_TEAM_NAME": "REDACTED_TEAM_NAME",
-		"ALLOWED_USERS": "REDACTED_EMAIL_1"
-	}
+	// ACCESS_TEAM_NAME and ALLOWED_USERS are set via Cloudflare dashboard
+	// and in .dev.vars for local development. Not in wrangler.jsonc to avoid PII.
+	// Set via: Workers & Pages → fastmail-mcp-remote → Settings → Variables
 	/**
 	 * Static Assets
 	 * https://developers.cloudflare.com/workers/static-assets/binding/


### PR DESCRIPTION
## Summary

- **Role-based access control**: `admin` (full access) vs `delegate` (read + inbox management + drafts only) with per-user config stored in KV
- **Category-based tool hiding**: Disable unused tool categories (e.g., calendar, contacts) per-user to reduce token usage in `tools/list` responses
- **SSE routing fix**: Register both `/sse` and `/sse/*` to handle SDK's `POST /sse/message`

### How it works

Permission config lives in KV (`config:permissions`) with a 5-minute module-level cache — update anytime via `wrangler kv:key put`, no redeploy needed.

Two interception points in Hono routes:
1. **`tools/call`** — parse JSON-RPC body before SDK, return error if tool denied
2. **`tools/list`** — filter SDK response to remove tools from disabled categories

### Delegate restrictions

| Allowed | Denied |
|---------|--------|
| Read email, search, threads | `send_email` |
| Inbox management (move, delete, flag) | `create_calendar_event` |
| `create_draft`, `reply_to_email` (draft mode) | `reply_to_email` with `sendImmediately: true` |

### Files

| File | Change |
|------|--------|
| `src/permissions.ts` | New — types, tool categories, KV cache, permission checks, response filtering |
| `src/index.ts` | Modified — import, `/mcp` route permission hooks, SSE routing fix |
| `wrangler.jsonc` | Modified — add `lobster@shahine.com` to `ALLOWED_USERS` |
| `test/permissions.test.ts` | New — 25 unit tests |

## Test plan

- [x] `npm run type-check` passes
- [x] `npx vitest run test/permissions.test.ts` — 25/25 tests pass
- [ ] Deploy and seed KV config
- [ ] MCP Inspector: admin sees email tools, no calendar/contacts
- [ ] MCP Inspector: delegate can `create_draft` but `send_email` returns JSON-RPC error
- [ ] MCP Inspector: delegate `reply_to_email` works, but `sendImmediately: true` denied

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization and request interception on the core `/mcp` endpoint; misconfiguration or parsing edge cases could inadvertently over/under-authorize tool calls.
> 
> **Overview**
> Adds KV-configured, **role-based and category-based** authorization for MCP tool usage. New `src/permissions.ts` enforces `admin` vs `delegate` restrictions, supports per-user disabled categories, intercepts `tools/call` to return JSON-RPC errors on denied tools, and filters `tools/list` responses to hide disallowed tools.
> 
> Integrates these checks into the `/mcp` route in `src/index.ts` and removes the `/sse` endpoint from routing and the root endpoint metadata. Configuration/PII hygiene is tightened by moving `ACCESS_TEAM_NAME`/`ALLOWED_USERS` out of `wrangler.jsonc`, making their generated types generic strings, and adding `ALLOWED_USERS` to `.dev.vars.example`; comprehensive unit tests are added for the permission logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 197fbc15ffd3a0e87c5a7535fe941657278c7770. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->