### PR TITLE
Add memo tools for Fastmail private notes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -743,6 +743,85 @@ ${quotedContent}
       },
     );
 
+    // =====================
+    // MEMO TOOLS
+    // =====================
+
+    this.server.tool(
+      "create_memo",
+      "Add a private memo (note) to an email. Memos are personal annotations visible only to you, stored in Fastmail's Memos folder. Useful for reminders, tracking payment dates, or jotting notes about a conversation.",
+      {
+        emailId: z.string().describe("ID of the email to attach the memo to"),
+        text: z.string().describe("The memo text (plain text)"),
+      },
+      async ({ emailId, text }) => {
+        try {
+          const client = this.getJmapClient();
+          const result = await client.createMemo(emailId, text);
+          return {
+            content: [{ text: `Memo created successfully on "${result.subject}". Memo ID: ${result.memoId}`, type: "text" }],
+          };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ text: `Failed to create memo: ${errorMessage}`, type: "text" }],
+          };
+        }
+      },
+    );
+
+    this.server.tool(
+      "get_memo",
+      "Get the memo (private note) attached to an email, if one exists. Returns the memo text, creation date, and memo ID.",
+      {
+        emailId: z.string().describe("ID of the email to check for a memo"),
+      },
+      async ({ emailId }) => {
+        try {
+          const client = this.getJmapClient();
+          const memo = await client.getMemo(emailId);
+          if (!memo) {
+            return {
+              content: [{ text: "No memo found for this email.", type: "text" }],
+            };
+          }
+          return this.guardResponse("get_memo", memo);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ text: `Failed to get memo: ${errorMessage}`, type: "text" }],
+          };
+        }
+      },
+    );
+
+    this.server.tool(
+      "delete_memo",
+      "Delete the memo (private note) attached to an email.",
+      {
+        emailId: z.string().describe("ID of the email whose memo should be deleted"),
+      },
+      async ({ emailId }) => {
+        try {
+          const client = this.getJmapClient();
+          const deleted = await client.deleteMemo(emailId);
+          if (!deleted) {
+            return {
+              content: [{ text: "No memo found for this email.", type: "text" }],
+            };
+          }
+          return {
+            content: [{ text: "Memo deleted successfully.", type: "text" }],
+          };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ text: `Failed to delete memo: ${errorMessage}`, type: "text" }],
+          };
+        }
+      },
+    );
+
     this.server.tool(
       "get_mailbox_stats",
       "Get statistics for a mailbox (unread count, total emails, etc.)",
@@ -1018,6 +1097,9 @@ ${quotedContent}
           "bulk_move",
           "bulk_delete",
           "bulk_flag",
+          "create_memo",
+          "get_memo",
+          "delete_memo",
         ];
 
         const allContactsFunctions = ["list_contacts", "get_contact", "search_contacts"];

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -75,6 +75,11 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
 	bulk_delete: 'INBOX_MANAGE',
 	bulk_flag: 'INBOX_MANAGE',
 
+	// MEMO (private notes on emails)
+	create_memo: 'INBOX_MANAGE',
+	get_memo: 'EMAIL_READ',
+	delete_memo: 'INBOX_MANAGE',
+
 	// DRAFT
 	create_draft: 'DRAFT',
 

--- a/src/prompt-guard.ts
+++ b/src/prompt-guard.ts
@@ -268,6 +268,7 @@ const EXTERNAL_DATA_TOOLS = new Set([
   "list_calendar_events",
   "get_calendar_event",
   "list_calendars",
+  "get_memo",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Adds three new MCP tools: `create_memo`, `get_memo`, `delete_memo` for managing Fastmail's private memo/notes feature via JMAP
- Memos are stored as reply emails in Fastmail's special Memos mailbox (`role: "memos"`), linked via `In-Reply-To` header to the target email's `Message-Id`
- Registers new tools in permissions (`INBOX_MANAGE`/`EMAIL_READ`), prompt-guard (datamarking for `get_memo`), and capability listing

## How it works

Fastmail memos are elegantly simple under the hood — they're just emails:
1. **Create**: `Email/set` creates an email in the Memos mailbox with `inReplyTo` pointing to the target email's `messageId`, no recipients, and the memo text as the body
2. **Read**: `Email/query` filters the Memos mailbox by `header: ['In-Reply-To', targetMessageId]` to find the linked memo
3. **Delete**: `Email/set` with `destroy` permanently removes the memo email

## Test plan

- [ ] Deploy to Workers and test `create_memo` on a real email
- [ ] Verify the memo appears in Fastmail web UI with yellow highlight and `has:memo` search
- [ ] Test `get_memo` retrieves the correct memo text
- [ ] Test `delete_memo` removes the memo
- [ ] Test `get_memo` on an email with no memo returns "No memo found"
- [ ] Verify memo doesn't appear in Sent or other folders
- [ ] Test permissions: `get_memo` allowed for delegates, `create_memo`/`delete_memo` require `INBOX_MANAGE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)