### PR TITLE
feat: config-driven tool filtering for OpenClaw plugin

### DIFF
--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -1,9 +1,12 @@
 /**
  * OpenClaw plugin entry point for Fastmail.
  *
- * Registers 36 agent tools that shell out to the `fastmail` CLI.
+ * Registers agent tools that shell out to the `fastmail` CLI.
  * The CLI handles MCP connection, auth, and compact text formatting.
  * Zero runtime dependencies — just execFile to the CLI process.
+ *
+ * Supports `disabledCategories` config to skip tools whose server-side
+ * category is disabled, so agents only see tools they can actually use.
  */
 
 import { registerEmailTools } from "./src/tools/email.js";
@@ -22,11 +25,86 @@ export interface OpenClawApi {
   config?: Record<string, unknown>;
 }
 
+/**
+ * Map every plugin tool name to its server-side permission category.
+ * Categories must match the ToolCategory type in src/permissions.ts.
+ */
+const TOOL_CATEGORIES: Record<string, string> = {
+  // EMAIL_READ
+  fastmail_inbox: "EMAIL_READ",
+  fastmail_get_email: "EMAIL_READ",
+  fastmail_search_emails: "EMAIL_READ",
+  fastmail_get_thread: "EMAIL_READ",
+  fastmail_list_mailboxes: "EMAIL_READ",
+  fastmail_get_mailbox_stats: "EMAIL_READ",
+  fastmail_get_account_summary: "EMAIL_READ",
+  fastmail_list_identities: "EMAIL_READ",
+  fastmail_get_attachments: "EMAIL_READ",
+  fastmail_download_attachment: "EMAIL_READ",
+  fastmail_get_inbox_updates: "EMAIL_READ",
+  fastmail_get_memo: "EMAIL_READ",
+
+  // CONTACTS
+  fastmail_list_contacts: "CONTACTS",
+  fastmail_get_contact: "CONTACTS",
+  fastmail_search_contacts: "CONTACTS",
+
+  // CALENDAR_READ
+  fastmail_list_calendars: "CALENDAR_READ",
+  fastmail_list_events: "CALENDAR_READ",
+  fastmail_get_event: "CALENDAR_READ",
+
+  // CALENDAR_WRITE
+  fastmail_create_event: "CALENDAR_WRITE",
+
+  // INBOX_MANAGE
+  fastmail_mark_read: "INBOX_MANAGE",
+  fastmail_mark_unread: "INBOX_MANAGE",
+  fastmail_flag: "INBOX_MANAGE",
+  fastmail_unflag: "INBOX_MANAGE",
+  fastmail_delete: "INBOX_MANAGE",
+  fastmail_move: "INBOX_MANAGE",
+  fastmail_bulk_read: "INBOX_MANAGE",
+  fastmail_bulk_unread: "INBOX_MANAGE",
+  fastmail_bulk_flag: "INBOX_MANAGE",
+  fastmail_bulk_unflag: "INBOX_MANAGE",
+  fastmail_bulk_delete: "INBOX_MANAGE",
+  fastmail_bulk_move: "INBOX_MANAGE",
+  fastmail_create_memo: "INBOX_MANAGE",
+  fastmail_delete_memo: "INBOX_MANAGE",
+
+  // DRAFT
+  fastmail_create_draft: "DRAFT",
+
+  // REPLY
+  fastmail_reply_to_email: "REPLY",
+
+  // SEND
+  fastmail_send_email: "SEND",
+};
+
+/** Wrap the API to silently skip tools whose category is disabled. */
+function withCategoryFilter(api: OpenClawApi, disabled: Set<string>): OpenClawApi {
+  if (disabled.size === 0) return api;
+  return {
+    ...api,
+    registerTool(tool, opts) {
+      const category = TOOL_CATEGORIES[tool.name];
+      if (category && disabled.has(category)) return;
+      api.registerTool(tool, opts);
+    },
+  };
+}
+
 export default function register(api: OpenClawApi) {
   const cli = (api.config?.cliCommand as string) ?? "fastmail";
+  const disabledList = (api.config?.disabledCategories as string[]) ?? [];
+  const disabled = new Set(disabledList);
 
-  registerEmailTools(api, cli);
-  registerContactTools(api, cli);
-  registerCalendarTools(api, cli);
-  registerMemoTools(api, cli);
+  const filtered = withCategoryFilter(api, disabled);
+
+  registerEmailTools(filtered, cli);
+  registerContactTools(filtered, cli);
+  registerCalendarTools(filtered, cli);
+  registerMemoTools(filtered, cli);
 }

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -8,6 +8,25 @@
         "type": "string",
         "default": "fastmail",
         "description": "Path or alias for the fastmail CLI (default: 'fastmail')"
+      },
+      "disabledCategories": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "EMAIL_READ",
+            "CONTACTS",
+            "CALENDAR_READ",
+            "CALENDAR_WRITE",
+            "INBOX_MANAGE",
+            "DRAFT",
+            "REPLY",
+            "SEND",
+            "META"
+          ]
+        },
+        "default": [],
+        "description": "Tool categories to hide (must match server permissions config)"
       }
     }
   },

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastmail-cli",
-  "version": "1.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-cli",
-      "version": "1.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OpenClaw plugin for Fastmail email, contacts, and calendar",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

- Add `disabledCategories` config to the OpenClaw plugin so agents only see tools they can actually use
- Maps all 36 plugin tool names to their 9 server-side permission categories
- Uses a proxy pattern (`withCategoryFilter`) to skip registration at load time — zero changes to tool files
- Prevents wasted agent turns calling tools that return permission-denied errors

## How it works

Users add `disabledCategories` to their OpenClaw workspace config:
```json
{
  "disabledCategories": ["CONTACTS", "CALENDAR_READ", "CALENDAR_WRITE"]
}
```

At plugin registration time, tools in those categories are silently skipped. The downstream tool files (`email.ts`, `contacts.ts`, etc.) are unchanged — filtering happens via a proxied `registerTool()`.

## Test plan

- [ ] Type-check passes: `cd openclaw-plugin && npx tsc --noEmit`
- [ ] Pack succeeds: `npm pack --dry-run`
- [ ] With empty `disabledCategories` (default): all 36 tools registered
- [ ] With `["CONTACTS", "CALENDAR_READ", "CALENDAR_WRITE"]`: contact/calendar tools hidden, email tools still registered
- [ ] Category names match `src/permissions.ts` ToolCategory type

🤖 Generated with [Claude Code](https://claude.com/claude-code)