### PR TITLE
feat: emit X-Token-Expires-At so CLI can track server-side token renewal

### DIFF
--- a/cli/auth.ts
+++ b/cli/auth.ts
@@ -39,6 +39,23 @@ export async function saveConfig(config: Config): Promise<void> {
   await writeFile(CONFIG_FILE, JSON.stringify(config, null, 2), { mode: 0o600 });
 }
 
+/**
+ * Update the cached tokenExpiresAt from a server-supplied value (e.g. the
+ * X-Token-Expires-At response header). No-op when the cached value already
+ * matches, or when there is no config file (pre-auth). Best-effort: silently
+ * swallows write errors so a transient FS problem doesn't break API calls.
+ */
+export async function updateTokenExpiry(newExpiresAt: string): Promise<void> {
+  try {
+    const config = await loadConfig();
+    if (!config || config.tokenExpiresAt === newExpiresAt) return;
+    config.tokenExpiresAt = newExpiresAt;
+    await saveConfig(config);
+  } catch {
+    // best-effort; surfacing errors here would mask the underlying API success
+  }
+}
+
 function generateCodeVerifier(): string {
   return randomBytes(32).toString("base64url");
 }
@@ -348,7 +365,7 @@ export async function authenticateHeadless(
   await saveAndReport(baseUrl, resolvedTeamName || "", "direct-token", token, expiresAt);
 }
 
-/** Load and validate the cached token, or exit with an error. */
+/** Load the cached token, or exit with an error if unauthenticated. */
 export async function getToken(): Promise<{ url: string; token: string }> {
   const config = await loadConfig();
   if (!config?.token) {
@@ -358,9 +375,19 @@ export async function getToken(): Promise<{ url: string; token: string }> {
     process.exit(1);
   }
 
+  // Don't self-terminate on a stale cached expiry. The server applies sliding
+  // window renewal on every successful call, but older CLI versions didn't
+  // persist the refreshed expiry locally, so the cache can look expired even
+  // when the server would still accept the token. Warn and fall through — a
+  // real 401 from the server (handled in mcp-client) will prompt re-auth.
   if (new Date(config.tokenExpiresAt) < new Date()) {
-    console.error("Token expired. Run: fastmail auth");
-    process.exit(1);
+    const stale = Math.max(
+      0,
+      Math.floor((Date.now() - new Date(config.tokenExpiresAt).getTime()) / 86400000),
+    );
+    console.error(
+      `Warning: cached token expiry is ${stale}d stale. Attempting call anyway; the server will reject if the token is truly expired.`,
+    );
   }
 
   return { url: config.url, token: config.token };

--- a/cli/mcp-client.ts
+++ b/cli/mcp-client.ts
@@ -64,7 +64,10 @@ export class FastmailMcpClient {
       headers.set("Authorization", `Bearer ${token}`);
       const response = await fetch(input, { ...init, headers });
       const renewed = response.headers.get("X-Token-Expires-At");
-      if (renewed) {
+      // Validate as a parseable ISO date before trusting it. A malformed header
+      // (misconfigured proxy, future server regression) would otherwise poison
+      // config.tokenExpiresAt and turn every `new Date(...)` into Invalid Date.
+      if (renewed && !Number.isNaN(new Date(renewed).getTime())) {
         // Fire-and-forget: never block or break the request on cache write failures
         updateTokenExpiry(renewed).catch(() => {});
       }

--- a/cli/mcp-client.ts
+++ b/cli/mcp-client.ts
@@ -8,6 +8,7 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { updateTokenExpiry } from "./auth.js";
 
 /**
  * Strip prompt-injection datamarking from MCP tool responses.
@@ -53,12 +54,21 @@ export class FastmailMcpClient {
       version: "1.0.0",
     });
 
-    // Inject Bearer token into every request via custom fetch
+    // Inject Bearer token into every request via custom fetch.
+    // Also intercept the response to persist any server-issued X-Token-Expires-At
+    // header — this is how the CLI learns that the Worker just slid the token's
+    // TTL forward, so the local config stops drifting from server-side reality.
     const token = this.token;
-    const authFetch: typeof fetch = (input, init) => {
+    const authFetch: typeof fetch = async (input, init) => {
       const headers = new Headers(init?.headers);
       headers.set("Authorization", `Bearer ${token}`);
-      return fetch(input, { ...init, headers });
+      const response = await fetch(input, { ...init, headers });
+      const renewed = response.headers.get("X-Token-Expires-At");
+      if (renewed) {
+        // Fire-and-forget: never block or break the request on cache write failures
+        updateTokenExpiry(renewed).catch(() => {});
+      }
+      return response;
     };
 
     const transport = new StreamableHTTPClientTransport(

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,18 @@ app.get("/get-token/callback", async (c) => {
   return handleGetTokenCallback(c.req.raw, c.env, new URL(c.req.url));
 });
 
+// Re-wrap a Response to add X-Token-Expires-At so CLI clients can track
+// the server's sliding-window renewal and refresh their local cache.
+function withTokenExpiresAt(response: Response, expiresAt: string): Response {
+  const headers = new Headers(response.headers);
+  headers.set("X-Token-Expires-At", expiresAt);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 // Helper to create 401 response with proper WWW-Authenticate header for MCP OAuth
 function unauthorizedResponse(c: { req: { url: string } }, error: string, description: string): Response {
   const url = new URL(c.req.url);
@@ -240,7 +252,8 @@ app.post("/mcp/code", async (c) => {
   // Serve via stateless WebStandard streamable HTTP transport
   const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
   await codeServer.connect(transport);
-  return transport.handleRequest(c.req.raw);
+  const response = await transport.handleRequest(c.req.raw);
+  return withTokenExpiresAt(response, tokenInfo.expiresAt);
 });
 
 // GET /mcp — Reject SSE stream requests (stateless transport, no session to stream to).
@@ -291,7 +304,8 @@ app.post("/mcp", async (c) => {
   // Serve via stateless WebStandard streamable HTTP transport (supports elicitation)
   const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
   await server.connect(transport);
-  return transport.handleRequest(c.req.raw);
+  const response = await transport.handleRequest(c.req.raw);
+  return withTokenExpiresAt(response, tokenInfo.expiresAt);
 });
 
 // Attachment download proxy endpoint (no auth required - uses single-use token)

--- a/src/oauth-utils.ts
+++ b/src/oauth-utils.ts
@@ -131,10 +131,13 @@ export interface OAuthClientData {
 // Validate access token (KV-based) with sliding window renewal.
 // Each successful validation extends the token TTL by TOKEN_TTL_SECONDS,
 // so tokens only expire if unused for 30 consecutive days.
+// Callers should surface `expiresAt` back to clients (e.g. via an
+// X-Token-Expires-At response header) so the client cache can track the
+// renewed expiry instead of staying frozen at mint time.
 export async function validateAccessToken(
 	kv: KVNamespace,
 	token: string
-): Promise<{ user_id: string; user_login: string; scope: string | null } | null> {
+): Promise<{ user_id: string; user_login: string; scope: string | null; expiresAt: string } | null> {
 	const tokenHash = await hashToken(token);
 	const data = await kv.get<OAuthTokenData>(`token:${tokenHash}`, 'json');
 
@@ -156,5 +159,6 @@ export async function validateAccessToken(
 		user_id: data.user_id,
 		user_login: data.user_login,
 		scope: data.scope,
+		expiresAt: data.expires_at,
 	};
 }


### PR DESCRIPTION
## Problem

\`validateAccessToken\` (src/oauth-utils.ts) has done silent sliding-window TTL renewal on every successful call for a while, which is great server-side. But the CLI never learned about it — its cached \`tokenExpiresAt\` in \`~/.config/fastmail-cli/config.json\` was frozen at mint time.

That turned the "30-day sliding window" into an effective hard cliff: after 30 days, \`getToken()\` in \`cli/auth.ts\` saw the stale cache and refused to even attempt a call, even though the server had long since extended the real expiry.

Detected while building a token-expiry monitor over on the Lobster side: Fastmail's \`config.json\` mtime was 25 days stale with 6 days remaining on the cached expiry — a smoking gun that the CLI had never heard about the sliding window.

## Fix

Make the renewal **visible** end-to-end:

**Worker side (\`src/\`):**
- \`validateAccessToken\` now returns the renewed \`expiresAt\` alongside user info
- Both \`/mcp\` and \`/mcp/code\` handlers re-wrap their responses to include an \`X-Token-Expires-At\` header so callers see the newly extended expiry
- Purely additive — unchanged for any client that ignores the header

**CLI side (\`cli/\`):**
- \`authFetch\` inspects every response; if the server announced a new expiry, the CLI rewrites \`~/.config/fastmail-cli/config.json\` in the background (fire-and-forget; cache write never blocks or fails a call)
- \`getToken()\` no longer \`process.exit(1)\`s on a stale cached expiry. It warns and falls through — the server's 401 is the authoritative "token dead" signal, not the local cache

## Test plan

- [x] \`npm run type-check\` (errors are all pre-existing Worker env-type issues unrelated to this diff)
- [x] CLI smoke test: \`fastmail account\` still works against currently-deployed (unpatched) server; config.json mtime unchanged (header absent → no spurious write)
- [ ] After Worker deploy: \`fastmail account\` should advance \`tokenExpiresAt\` by ~30 days and bump config.json mtime
- [ ] After Worker deploy: Lobster \`auth-health-check\` should report \`remaining_days: ~30\` and \`days_since_config_write: ~0\` for fastmail-cli

## Deploy note

This Worker has no CI workflow (\`deploy-site.yml\` only deploys the Astro \`site/\`). The MCP Worker itself has always been deployed manually via \`wrangler deploy\` — that still applies here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)