### PR TITLE
Verify Cloudflare Access ID tokens

### DIFF
--- a/src/oauth-handler.ts
+++ b/src/oauth-handler.ts
@@ -13,6 +13,7 @@ import {
 	isUserAllowed,
 	verifyCodeChallenge,
 	validateRefreshToken,
+	verifyAccessIdToken,
 	STATE_TTL_SECONDS,
 	CODE_TTL_SECONDS,
 	TOKEN_TTL_SECONDS,
@@ -297,11 +298,11 @@ export async function handleCallback(request: Request, env: Env, url: URL): Prom
 			throw new Error(tokenData.error_description || tokenData.error);
 		}
 
-		// Decode ID token to get user info
 		const idToken = tokenData.id_token!;
-		const parts = idToken.split('.');
-		const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
-		const userInfo = { sub: payload.sub, email: payload.email, name: payload.name };
+		const userInfo = await verifyAccessIdToken(idToken, {
+			teamName,
+			clientId: env.ACCESS_CLIENT_ID,
+		});
 
 		// Check if user is allowed
 		if (!isUserAllowed(userInfo.email, env.ALLOWED_USERS || '')) {
@@ -882,10 +883,11 @@ export async function handleGetTokenCallback(request: Request, env: Env, url: UR
 			throw new Error(tokenData.error || 'No ID token received');
 		}
 
-		// Decode ID token to get user info
-		const parts = tokenData.id_token.split('.');
-		const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
-		const userEmail = payload.email;
+		const userInfo = await verifyAccessIdToken(tokenData.id_token, {
+			teamName,
+			clientId: env.ACCESS_CLIENT_ID,
+		});
+		const userEmail = userInfo.email;
 
 		// Check if user is allowed
 		if (!isUserAllowed(userEmail, env.ALLOWED_USERS || '')) {
@@ -899,7 +901,7 @@ export async function handleGetTokenCallback(request: Request, env: Env, url: UR
 
 		const mcpTokenData: OAuthTokenData = {
 			client_id: 'direct-token',
-			user_id: payload.sub,
+			user_id: userInfo.sub,
 			user_login: userEmail,
 			scope: DEFAULT_SCOPE,
 			expires_at: tokenExpiresAt,

--- a/src/oauth-utils.ts
+++ b/src/oauth-utils.ts
@@ -17,6 +17,174 @@ export function getAccessBaseUrl(teamName: string): string {
 	return `https://${teamName}.cloudflareaccess.com/cdn-cgi/access/sso/oidc`;
 }
 
+export interface AccessIdTokenClaims {
+	sub: string;
+	email: string;
+	name?: string;
+	iss: string;
+	aud: string | string[];
+	exp: number;
+	iat?: number;
+}
+
+interface AccessJsonWebKey extends JsonWebKey {
+	kid?: string;
+	alg?: string;
+	use?: string;
+}
+
+interface AccessJwks {
+	keys: AccessJsonWebKey[];
+}
+
+const JWT_CLOCK_SKEW_SECONDS = 60;
+
+function base64UrlToBytes(value: string): Uint8Array {
+	const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+	const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+	const binary = atob(padded);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return bytes;
+}
+
+function decodeJwtPart(value: string): unknown {
+	const bytes = base64UrlToBytes(value);
+	const json = new TextDecoder().decode(bytes);
+	return JSON.parse(json);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function assertStringClaim(claims: Record<string, unknown>, name: string): string {
+	const value = claims[name];
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new Error(`Access ID token missing ${name}`);
+	}
+	return value;
+}
+
+function assertNumberClaim(claims: Record<string, unknown>, name: string): number {
+	const value = claims[name];
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		throw new Error(`Access ID token missing ${name}`);
+	}
+	return value;
+}
+
+function validateAudience(audience: unknown, clientId: string): string | string[] {
+	if (typeof audience === 'string') {
+		if (audience !== clientId) {
+			throw new Error('Access ID token audience mismatch');
+		}
+		return audience;
+	}
+	if (Array.isArray(audience) && audience.every((item) => typeof item === 'string')) {
+		if (!audience.includes(clientId)) {
+			throw new Error('Access ID token audience mismatch');
+		}
+		return audience;
+	}
+	throw new Error('Access ID token missing aud');
+}
+
+async function importAccessSigningKey(jwk: AccessJsonWebKey): Promise<CryptoKey> {
+	return crypto.subtle.importKey(
+		'jwk',
+		jwk,
+		{
+			name: 'RSASSA-PKCS1-v1_5',
+			hash: 'SHA-256',
+		},
+		false,
+		['verify']
+	);
+}
+
+export async function verifyAccessIdToken(
+	idToken: string,
+	args: { teamName: string; clientId: string; now?: Date }
+): Promise<AccessIdTokenClaims> {
+	const parts = idToken.split('.');
+	if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+		throw new Error('Access ID token must be a signed JWT');
+	}
+
+	const header = decodeJwtPart(parts[0]);
+	const payload = decodeJwtPart(parts[1]);
+	if (!isRecord(header) || !isRecord(payload)) {
+		throw new Error('Access ID token is malformed');
+	}
+
+	if (header.alg !== 'RS256') {
+		throw new Error('Access ID token uses unsupported alg');
+	}
+	const kid = assertStringClaim(header, 'kid');
+
+	const accessBaseUrl = getAccessBaseUrl(args.teamName);
+	const issuer = `${accessBaseUrl}/${args.clientId}`;
+	const jwksUrl = `${issuer}/jwks`;
+	const jwksResponse = await fetch(jwksUrl, {
+		headers: { Accept: 'application/json' },
+	});
+	if (!jwksResponse.ok) {
+		throw new Error(`Failed to fetch Access JWKs: ${jwksResponse.status}`);
+	}
+
+	const jwks = (await jwksResponse.json()) as AccessJwks;
+	const jwk = jwks.keys?.find((key) => key.kid === kid);
+	if (!jwk) {
+		throw new Error('Access ID token signing key not found');
+	}
+
+	const key = await importAccessSigningKey(jwk);
+	const signedData = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+	const signature = base64UrlToBytes(parts[2]);
+	const validSignature = await crypto.subtle.verify(
+		'RSASSA-PKCS1-v1_5',
+		key,
+		signature,
+		signedData
+	);
+	if (!validSignature) {
+		throw new Error('Access ID token signature invalid');
+	}
+
+	const tokenIssuer = assertStringClaim(payload, 'iss');
+	if (tokenIssuer !== issuer) {
+		throw new Error('Access ID token issuer mismatch');
+	}
+
+	const aud = validateAudience(payload.aud, args.clientId);
+	const exp = assertNumberClaim(payload, 'exp');
+	const nowSeconds = Math.floor((args.now ?? new Date()).getTime() / 1000);
+	if (exp <= nowSeconds - JWT_CLOCK_SKEW_SECONDS) {
+		throw new Error('Access ID token expired');
+	}
+
+	let iat: number | undefined;
+	if (payload.iat !== undefined) {
+		iat = assertNumberClaim(payload, 'iat');
+		if (iat > nowSeconds + JWT_CLOCK_SKEW_SECONDS) {
+			throw new Error('Access ID token issued in the future');
+		}
+	}
+
+	return {
+		sub: assertStringClaim(payload, 'sub'),
+		email: assertStringClaim(payload, 'email'),
+		name: typeof payload.name === 'string' ? payload.name : undefined,
+		iss: tokenIssuer,
+		aud,
+		exp,
+		iat,
+	};
+}
+
 // Generate cryptographically secure random string
 export function generateRandomString(length: number): string {
 	const array = new Uint8Array(length);

--- a/test/oauth-handler.test.ts
+++ b/test/oauth-handler.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handleGetTokenCallback } from '../src/oauth-handler';
+
+const TEAM_NAME = 'example-team';
+const CLIENT_ID = 'access-client-id';
+
+function base64UrlJson(value: unknown): string {
+	const base64 = Buffer.from(JSON.stringify(value)).toString('base64');
+	return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function unsignedIdToken(): string {
+	const issuer = `https://${TEAM_NAME}.cloudflareaccess.com/cdn-cgi/access/sso/oidc/${CLIENT_ID}`;
+	return `${base64UrlJson({ alg: 'none', typ: 'JWT' })}.${base64UrlJson({
+		iss: issuer,
+		aud: CLIENT_ID,
+		exp: Math.floor(Date.now() / 1000) + 300,
+		sub: 'forged-subject',
+		email: 'allowed@example.com',
+	})}.unsigned`;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('handleGetTokenCallback', () => {
+	it('rejects forged Access ID tokens before issuing MCP access tokens', async () => {
+		const kv = {
+			get: vi.fn(async () => JSON.stringify({ team_name: TEAM_NAME })),
+			delete: vi.fn(async () => undefined),
+			put: vi.fn(async () => undefined),
+		};
+		const env = {
+			OAUTH_KV: kv,
+			ACCESS_TEAM_NAME: TEAM_NAME,
+			ACCESS_CLIENT_ID: CLIENT_ID,
+			ACCESS_CLIENT_SECRET: 'client-secret',
+			ALLOWED_USERS: 'allowed@example.com',
+		} as unknown as Env;
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => Response.json({ id_token: unsignedIdToken() }))
+		);
+
+		const response = await handleGetTokenCallback(
+			new Request('https://worker.example/get-token/callback?code=abc&state=state-123'),
+			env,
+			new URL('https://worker.example/get-token/callback?code=abc&state=state-123')
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain('unsupported alg');
+		expect(kv.put).not.toHaveBeenCalled();
+	});
+});

--- a/test/oauth-utils.test.ts
+++ b/test/oauth-utils.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { verifyAccessIdToken } from '../src/oauth-utils';
+
+const TEAM_NAME = 'example-team';
+const CLIENT_ID = 'access-client-id';
+const ISSUER = `https://${TEAM_NAME}.cloudflareaccess.com/cdn-cgi/access/sso/oidc/${CLIENT_ID}`;
+const NOW = new Date('2026-05-17T12:00:00Z');
+
+interface TestJwk extends JsonWebKey {
+	kid?: string;
+	alg?: string;
+	use?: string;
+}
+
+function base64Url(input: string | Uint8Array): string {
+	const base64 = Buffer.from(input).toString('base64');
+	return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function encodeJson(value: unknown): string {
+	return base64Url(JSON.stringify(value));
+}
+
+async function createSignedJwt(
+	claims: Record<string, unknown>,
+	args: { kid?: string; keyPair?: CryptoKeyPair } = {}
+): Promise<{ token: string; publicJwk: TestJwk }> {
+	const keyPair =
+		args.keyPair ??
+		((await crypto.subtle.generateKey(
+			{
+				name: 'RSASSA-PKCS1-v1_5',
+				modulusLength: 2048,
+				publicExponent: new Uint8Array([1, 0, 1]),
+				hash: 'SHA-256',
+			},
+			true,
+			['sign', 'verify']
+		)) as CryptoKeyPair);
+	const kid = args.kid ?? 'test-key';
+	const header = encodeJson({ alg: 'RS256', typ: 'JWT', kid });
+	const payload = encodeJson(claims);
+	const signedData = new TextEncoder().encode(`${header}.${payload}`);
+	const signature = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', keyPair.privateKey, signedData);
+	const publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as JsonWebKey;
+	return {
+		token: `${header}.${payload}.${base64Url(new Uint8Array(signature))}`,
+		publicJwk: { ...publicJwk, kid, alg: 'RS256', use: 'sig' },
+	};
+}
+
+function mockJwks(publicJwk: TestJwk): void {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => Response.json({ keys: [publicJwk] }))
+	);
+}
+
+function validClaims(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		iss: ISSUER,
+		aud: CLIENT_ID,
+		exp: Math.floor(NOW.getTime() / 1000) + 300,
+		iat: Math.floor(NOW.getTime() / 1000) - 30,
+		sub: 'user-subject',
+		email: 'user@example.com',
+		name: 'User Example',
+		...overrides,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe('verifyAccessIdToken', () => {
+	it('rejects unsigned JWTs before trusting claims', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+		const token = `${encodeJson({ alg: 'none', typ: 'JWT' })}.${encodeJson(
+			validClaims()
+		)}.unsigned`;
+
+		await expect(
+			verifyAccessIdToken(token, { teamName: TEAM_NAME, clientId: CLIENT_ID, now: NOW })
+		).rejects.toThrow('unsupported alg');
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('rejects JWTs with an invalid signature', async () => {
+		const { token, publicJwk } = await createSignedJwt(validClaims());
+		mockJwks(publicJwk);
+		const forgedToken = `${token.slice(0, -2)}xx`;
+
+		await expect(
+			verifyAccessIdToken(forgedToken, { teamName: TEAM_NAME, clientId: CLIENT_ID, now: NOW })
+		).rejects.toThrow('signature invalid');
+	});
+
+	it('accepts a signed Access ID token with valid issuer, audience, expiry, and identity claims', async () => {
+		const { token, publicJwk } = await createSignedJwt(validClaims());
+		mockJwks(publicJwk);
+
+		const claims = await verifyAccessIdToken(token, {
+			teamName: TEAM_NAME,
+			clientId: CLIENT_ID,
+			now: NOW,
+		});
+
+		expect(claims).toMatchObject({
+			sub: 'user-subject',
+			email: 'user@example.com',
+			name: 'User Example',
+			iss: ISSUER,
+			aud: CLIENT_ID,
+		});
+		expect(fetch).toHaveBeenCalledWith(`${ISSUER}/jwks`, {
+			headers: { Accept: 'application/json' },
+		});
+	});
+
+	it('rejects a validly signed token for the wrong audience', async () => {
+		const { token, publicJwk } = await createSignedJwt(validClaims({ aud: 'other-client' }));
+		mockJwks(publicJwk);
+
+		await expect(
+			verifyAccessIdToken(token, { teamName: TEAM_NAME, clientId: CLIENT_ID, now: NOW })
+		).rejects.toThrow('audience mismatch');
+	});
+});


### PR DESCRIPTION
## Summary
- verify Cloudflare Access ID tokens against the Access OIDC JWKS endpoint before trusting identity claims
- validate issuer, audience, expiry, issued-at, subject, and email in both OAuth callback paths
- add unit and callback regression coverage for forged and valid ID tokens

## Root cause
The OAuth callbacks decoded the JWT payload directly and trusted email/sub without signature or claim validation.

## Validation
- npm run type-check
- npm run test

Clawpatch finding: fnd_sig-feat-service-95da868dea-75c1_33f4ecb6f8