### PR TITLE
chore: release Fastmail plugin 3.1.5

### DIFF
--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastmail-cli",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-cli",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
         "openclaw": "^2026.6.5"

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-cli",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "OpenClaw plugin for Fastmail email, contacts, and calendar",
   "type": "module",
   "files": [


### PR DESCRIPTION
Version bump for the OpenClaw SDK refresh. Version consistency was checked locally before pushing.