### PR TITLE
feat: add update_draft tool to edit draft bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ openclaw-plugin/                     # OpenClaw plugin: "fastmail-cli" on npm
 ├── src/
 │   ├── cli-runner.ts                # execFile wrapper, buildArgs, runTool helpers
 │   └── tools/
-│       ├── email.ts                 # 26 email tools (read + write + organize + bulk)
+│       ├── email.ts                 # 27 email tools (read + write + organize + bulk)
 │       ├── contacts.ts              # 3 contact tools
 │       ├── calendar.ts              # 4 calendar tools
 │       └── memo.ts                  # 3 memo tools
@@ -143,7 +143,7 @@ curl https://<your-worker-domain>/
 
 ## OpenClaw Plugin (npm: fastmail-cli)
 
-The `openclaw-plugin/` directory is published to npm as `fastmail-cli`. It registers 36 OpenClaw agent tools that shell out to the `fastmail` CLI. Zero runtime dependencies — the CLI handles MCP connection, auth, and formatting.
+The `openclaw-plugin/` directory is published to npm as `fastmail-cli`. It registers 37 OpenClaw agent tools that shell out to the `fastmail` CLI. Zero runtime dependencies — the CLI handles MCP connection, auth, and formatting.
 
 ```
 Agent -> Plugin -> execFile(fastmail, args) -> CLI -> MCP SDK -> Remote Worker -> Fastmail JMAP

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fastmail has a powerful API ([JMAP](https://jmap.io/)) and supports IMAP, but it
 
 - **Any MCP client** (Claude.ai, Claude Code, GitHub Copilot) connects directly to the Worker via OAuth
 - **[Fastmail CLI](cli/)** — a local command-line tool that calls the Worker and formats responses as compact text, saving 5-7x tokens
-- **[Fastmail CLI for OpenClaw](openclaw-plugin/)** — an OpenClaw plugin (36 agent tools) published as [`fastmail-cli` on npm](https://www.npmjs.com/package/fastmail-cli)
+- **[Fastmail CLI for OpenClaw](openclaw-plugin/)** — an OpenClaw plugin (37 agent tools) published as [`fastmail-cli` on npm](https://www.npmjs.com/package/fastmail-cli)
 
 ## Architecture
 
@@ -104,6 +104,7 @@ cli/
 - `get_email` - Get a specific email by ID (includes threading: messageId, inReplyTo, references, threadId)
 - `send_email` - Send an email (supports attachments and reply threading)
 - `create_draft` - Create a draft email (supports attachments and reply threading)
+- `update_draft` - Edit an existing draft's body (creates a replacement draft — the ID changes; re-derives the quoted original for reply drafts)
 - `reply_to_email` - Reply to an email with automatic threading and quoting (like Fastmail's reply button)
 - `search_emails` - Search emails
 - `get_recent_emails` - Get most recent emails
@@ -460,7 +461,7 @@ The server supports role-based access control with two layers:
 | `CALENDAR_READ` | list_calendars, list_calendar_events, get_calendar_event | Yes | Yes |
 | `CALENDAR_WRITE` | create_calendar_event | Yes | No |
 | `INBOX_MANAGE` | mark_email_read, flag_email, delete_email, move_email, bulk_mark_read, bulk_move, bulk_delete, bulk_flag, create_memo, delete_memo, generate_email_action_urls | Yes | Yes |
-| `DRAFT` | create_draft | Yes | Yes |
+| `DRAFT` | create_draft, update_draft | Yes | Yes |
 | `REPLY` | reply_to_email | Yes | Yes* |
 | `SEND` | send_email | Yes | No |
 | `META` | check_function_availability | Yes | Yes |

--- a/cli/commands/email.ts
+++ b/cli/commands/email.ts
@@ -268,6 +268,39 @@ export function registerEmailCommands(
       console.log(typeof result === "string" ? result : JSON.stringify(result));
     });
 
+  // ── email update-draft ───────────────────────────────────
+
+  email
+    .command("update-draft <draftId>")
+    .description("Edit an existing draft's body (creates a replacement — the draft ID changes)")
+    .requiredOption("--body <text>", "New message body (plain text)")
+    .option("--html <text>", "New HTML body")
+    .option("--markdown <text>", "New Markdown body")
+    .option("--reply-to <emailId>", "For reply drafts: source email ID to regenerate the quoted original")
+    .option("--no-quote", "Exclude quoted original (body becomes the entire draft)")
+    .option("--dry-run", "Preview what would be updated without updating")
+    .action(async (draftId, opts) => {
+      validateIds(draftId, "draft ID");
+      validateTextArg(opts.body, "body");
+      if (opts.html) validateTextArg(opts.html, "HTML body");
+      if (opts.markdown) validateTextArg(opts.markdown, "markdown body");
+      if (opts.replyTo) validateIds(opts.replyTo, "reply-to email ID");
+
+      const args = {
+        draftId,
+        body: opts.body,
+        htmlBody: opts.html,
+        markdownBody: opts.markdown,
+        replyToEmailId: opts.replyTo,
+        excludeQuote: !opts.quote,
+      };
+
+      if (opts.dryRun) return dryRunOutput("update_draft", args);
+
+      const result = await client.callTool("update_draft", args);
+      console.log(typeof result === "string" ? result : JSON.stringify(result));
+    });
+
   // ── email mark actions ───────────────────────────────────
 
   email

--- a/cli/skill.md
+++ b/cli/skill.md
@@ -53,6 +53,8 @@ fastmail email draft --to user@example.com --subject "Draft" --body "..."   # NE
 fastmail email reply <id> --body "Thanks!"           # Save reply as draft (default, correct for replies)
 fastmail email reply <id> --body "Thanks!" --send    # Send reply immediately (confirm with user first)
 fastmail email reply <id> --body "Noted" --all       # Reply all (only when user selected reply-all)
+fastmail email update-draft <draftId> --body "Revised text"                 # Edit an existing draft's body
+fastmail email update-draft <draftId> --body "Revised" --reply-to <srcId>   # Edit a reply draft, regenerate the quote
 ```
 
 ### Replies — Critical Rules
@@ -61,6 +63,12 @@ fastmail email reply <id> --body "Noted" --all       # Reply all (only when user
 - **Draft vs. send:** `fastmail email reply` saves as a draft by default (the user reviews in Fastmail, then hits send). Only pass `--send` when the user explicitly asked to send the reply right now — and confirm once more before doing so.
 - **Reply-all:** Pass `--all` only when the user explicitly selected "reply all". The default is reply-to-sender-only.
 - **Quoting:** `fastmail email reply` quotes the original message automatically. Don't paste the original body into `--body`.
+
+### Editing a Draft
+
+- **`fastmail email update-draft <draftId>`** edits an existing draft's body. JMAP bodies are immutable, so this replaces the draft — **the draft ID changes**. Use the new ID printed in the output for any further edits.
+- Recipients, subject, sender, threading, and attachments are preserved automatically. Pass only the new `--body` (plus optional `--html`/`--markdown`).
+- **For reply drafts:** provide only your message text. The quoted original is re-derived and re-appended — pass `--reply-to <sourceEmailId>` to point at the email being replied to, or omit it to let the draft's `In-Reply-To` header locate the source automatically. Use `--no-quote` to drop the quote entirely.
 
 > **Regression guard for agents:** If your plan has a "draft a reply" branch that calls `fastmail email draft` (CLI) or `create_draft` (MCP), that is a bug. Route the branch to `fastmail email reply <id>` (CLI) or `reply_to_email` (MCP) with `sendImmediately=false`.
 

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -112,6 +112,7 @@ const TOOL_CATEGORIES: Record<string, string> = {
 
   // DRAFT
   fastmail_create_draft: "DRAFT",
+  fastmail_update_draft: "DRAFT",
 
   // REPLY
   fastmail_reply_to_email: "REPLY",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-cli",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "description": "OpenClaw plugin for Fastmail email, contacts, and calendar",
   "type": "module",
   "files": [

--- a/openclaw-plugin/skills/fastmail/SKILL.md
+++ b/openclaw-plugin/skills/fastmail/SKILL.md
@@ -30,6 +30,7 @@ The `fastmail` CLI must be installed and authenticated before using these tools.
 |------|---------|
 | `fastmail_send_email` | Send a NEW email (text, HTML, or markdown body) |
 | `fastmail_create_draft` | Create a NEW draft (no source email). **Never use for replies.** |
+| `fastmail_update_draft` | Edit an existing draft's body. **The draft ID changes** — use the returned new ID afterward. |
 | `fastmail_reply_to_email` | Reply to an email. Use this for ALL replies — draft OR send. |
 
 ### Replies — Critical Rules
@@ -38,6 +39,12 @@ The `fastmail` CLI must be installed and authenticated before using these tools.
 - **Draft vs. send:** `fastmail_reply_to_email` defaults to `sendImmediately: false` (saves as a draft). Leave it as the default. Only pass `sendImmediately: true` when the user has explicitly asked to send the reply right now — and confirm once more before doing so.
 - **Reply-all:** Pass `replyAll: true` only when the user explicitly selected "reply all". The default is reply-to-sender-only.
 - **Quoting:** `fastmail_reply_to_email` quotes the original message automatically. Don't paste the original body into your reply content.
+
+### Editing a Draft
+
+- **`fastmail_update_draft`** edits an existing draft's body. JMAP bodies are immutable, so it replaces the draft — **the draft ID changes**. Use the new ID from the response for any further edits.
+- Recipients, subject, sender, threading, and attachments are preserved. Provide only the new `body` (plus optional `htmlBody`/`markdownBody`).
+- **For reply drafts:** pass only your message text. The quoted original is re-derived and re-appended — pass `replyToEmailId` (the email being replied to) to regenerate it, or omit it to auto-locate the source via the draft's `In-Reply-To` header. Pass `excludeQuote: true` to drop the quote.
 
 ### Email Organization (6 optional tools)
 

--- a/openclaw-plugin/src/tools/email.ts
+++ b/openclaw-plugin/src/tools/email.ts
@@ -240,6 +240,29 @@ export function registerEmailTools(api: PluginApi, cli: string) {
       }), cli),
   }, { optional: true });
 
+  api.registerTool({
+    name: "fastmail_update_draft",
+    description:
+      "Edit an existing draft's body. JMAP bodies are immutable, so this creates a replacement draft and deletes the old one — the draft ID changes (use the returned new ID for further edits). Recipients, subject, sender, threading, and attachments are preserved. For a reply draft, pass only your message text; the quoted original is re-derived and re-appended (from replyToEmailId if given, otherwise via the draft's In-Reply-To header).",
+    parameters: {
+      type: "object",
+      properties: {
+        draftId: { type: "string", description: "ID of the draft to edit" },
+        body: { type: "string", description: "New message body (plain text). For reply drafts, only your message — the quote is re-appended automatically." },
+        htmlBody: { type: "string", description: "New HTML body" },
+        markdownBody: { type: "string", description: "New Markdown body" },
+        replyToEmailId: { type: "string", description: "For reply drafts: source email ID used to regenerate the quoted original. If omitted, the draft's In-Reply-To header is used." },
+        excludeQuote: { type: "boolean", default: false, description: "Exclude quoted original — body becomes the entire draft" },
+      },
+      required: ["draftId", "body"],
+    },
+    execute: (_id, params: { draftId: string; body: string; htmlBody?: string; markdownBody?: string; replyToEmailId?: string; excludeQuote?: boolean }) =>
+      runTool(buildArgs(["email", "update-draft", params.draftId], {
+        body: params.body, html: params.htmlBody, markdown: params.markdownBody,
+        "reply-to": params.replyToEmailId, "no-quote": params.excludeQuote,
+      }), cli),
+  }, { optional: true });
+
   // -- Organize (6 tools, optional) -----------------------------------
 
   api.registerTool({

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -625,6 +625,147 @@ export class JmapClient {
     return emailResult.created?.draft?.id || 'unknown';
   }
 
+  /**
+   * Find an email by its RFC5322 Message-ID header value (the bare id, no angle
+   * brackets — same form as the `messageId`/`inReplyTo` fields JMAP returns).
+   * Used to locate the source of a reply draft so its quote can be regenerated.
+   * Returns the first match (with full text + HTML body values) or null.
+   */
+  async getEmailByMessageId(messageId: string): Promise<any | null> {
+    const session = await this.getSession();
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/query', {
+          accountId: session.accountId,
+          filter: { header: ['Message-Id', messageId] },
+          limit: 1,
+        }, 'query'],
+        ['Email/get', {
+          accountId: session.accountId,
+          '#ids': { resultOf: 'query', name: 'Email/query', path: '/ids' },
+          properties: ['id', 'subject', 'from', 'receivedAt', 'textBody', 'htmlBody', 'bodyValues', 'messageId', 'references'],
+          fetchTextBodyValues: true,
+          fetchHTMLBodyValues: true,
+        }, 'source'],
+      ],
+    };
+
+    const response = await this.makeRequest(request);
+    const list = response.methodResponses[1][1].list;
+    return list && list.length > 0 ? list[0] : null;
+  }
+
+  /**
+   * Edit the body of an existing draft. JMAP email bodies are immutable — the only
+   * mutable Email properties are `keywords` and `mailboxIds` — so "editing" a draft
+   * means creating a replacement with the new body and destroying the original. The
+   * new draft therefore gets a NEW id, which is returned.
+   *
+   * Everything except the body is preserved from the existing draft: recipients,
+   * subject, From identity, threading headers (inReplyTo/references), mailboxes, and
+   * attachments (re-referenced by blobId — no re-upload). Callers pass the final
+   * text/HTML body (any reply quote already appended), matching createDraft's contract.
+   *
+   * The create runs first as its own request; the destroy only runs once we have a
+   * valid replacement, so a failed create can never lose the draft's content. If the
+   * destroy then fails, the new draft is still good and we surface the leftover
+   * duplicate rather than silently leaving two copies.
+   */
+  async updateDraft(params: {
+    draftId: string;
+    textBody?: string;
+    htmlBody?: string;
+  }): Promise<string> {
+    const session = await this.getSession();
+
+    if (!params.textBody && !params.htmlBody) {
+      throw new Error('Either textBody or htmlBody must be provided');
+    }
+
+    const existing = await this.getEmailById(params.draftId);
+    if (!existing) {
+      throw new Error(`Draft not found: ${params.draftId}`);
+    }
+
+    // Guard: only edit true drafts. Destroying a sent or received message would be
+    // destructive, so refuse anything without the $draft keyword.
+    if (existing.keywords?.$draft !== true) {
+      throw new Error(`Email ${params.draftId} is not a draft — refusing to edit. Only messages in Drafts (with the $draft keyword) can be edited.`);
+    }
+
+    const emailObject: JmapEmailObject = {
+      mailboxIds: existing.mailboxIds,
+      keywords: existing.keywords || { $draft: true },
+      from: existing.from || undefined,
+      to: existing.to || [],
+      cc: existing.cc || [],
+      bcc: existing.bcc || [],
+      subject: existing.subject || '',
+      textBody: params.textBody ? [{ partId: 'text', type: 'text/plain' }] : undefined,
+      htmlBody: params.htmlBody ? [{ partId: 'html', type: 'text/html' }] : undefined,
+      bodyValues: {
+        ...(params.textBody && { text: { value: params.textBody } }),
+        ...(params.htmlBody && { html: { value: params.htmlBody } }),
+      },
+      ...(existing.inReplyTo && { inReplyTo: existing.inReplyTo }),
+      ...(existing.references && { references: existing.references }),
+    };
+
+    // Preserve attachments (including inline cid: images) by blobId — no re-upload.
+    if (existing.attachments && existing.attachments.length > 0) {
+      emailObject.attachments = existing.attachments.map((att: any) => ({
+        blobId: att.blobId,
+        type: att.type,
+        name: att.name,
+        ...(att.cid && { cid: att.cid }),
+        ...(att.disposition && { disposition: att.disposition }),
+      }));
+    }
+
+    // 1. Create the replacement draft first — never destroy before we have a good copy.
+    const createResponse = await this.makeRequest({
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          create: { draft: emailObject },
+        }, 'createDraft'],
+      ],
+    });
+
+    const createResult = createResponse.methodResponses[0][1];
+    if (createResult.notCreated?.draft) {
+      const error = createResult.notCreated.draft;
+      throw new Error(`Failed to update draft: ${error.type || 'unknown error'}. ${error.description || ''}`);
+    }
+    const newId = createResult.created?.draft?.id;
+    if (!newId) {
+      throw new Error('Draft update did not return a new draft id');
+    }
+
+    // 2. Destroy the old draft. The replacement already exists, so a failure here means
+    // a recoverable duplicate — surface it rather than losing anything.
+    const destroyResponse = await this.makeRequest({
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          destroy: [params.draftId],
+        }, 'destroyOldDraft'],
+      ],
+    });
+
+    const destroyResult = destroyResponse.methodResponses[0][1];
+    if (destroyResult.notDestroyed?.[params.draftId]) {
+      const error = destroyResult.notDestroyed[params.draftId];
+      throw new Error(`Updated draft created as ${newId}, but the old draft ${params.draftId} could not be removed (${error.type || 'unknown'}). You now have two drafts — delete ${params.draftId} manually.`);
+    }
+
+    return newId;
+  }
+
   async sendEmail(email: {
     to: string[];
     cc?: string[];

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -487,7 +487,9 @@ export class JmapClient {
           accountId: session.accountId,
           ids: [id],
           properties: ['id', 'subject', 'from', 'replyTo', 'to', 'cc', 'bcc', 'receivedAt', 'preview', 'textBody', 'htmlBody', 'attachments', 'bodyValues', 'messageId', 'inReplyTo', 'references', 'threadId', 'keywords', 'mailboxIds'],
-          bodyProperties: ['partId', 'blobId', 'type', 'size', 'name'],
+          // cid + disposition are needed so callers preserving attachments (e.g. updateDraft)
+          // can re-reference inline cid: images correctly.
+          bodyProperties: ['partId', 'blobId', 'type', 'size', 'name', 'cid', 'disposition'],
           fetchTextBodyValues: true,
           fetchHTMLBodyValues: true,
         }, 'email']
@@ -677,6 +679,7 @@ export class JmapClient {
     draftId: string;
     textBody?: string;
     htmlBody?: string;
+    draft?: any;
   }): Promise<string> {
     const session = await this.getSession();
 
@@ -684,7 +687,9 @@ export class JmapClient {
       throw new Error('Either textBody or htmlBody must be provided');
     }
 
-    const existing = await this.getEmailById(params.draftId);
+    // Reuse a draft the caller already fetched (getEmailById) to avoid a redundant
+    // Email/get; fall back to fetching when called standalone.
+    const existing = params.draft ?? await this.getEmailById(params.draftId);
     if (!existing) {
       throw new Error(`Draft not found: ${params.draftId}`);
     }

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -82,6 +82,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
 
 	// DRAFT
 	create_draft: 'DRAFT',
+	update_draft: 'DRAFT',
 
 	// REPLY (dual behavior — checked specially for sendImmediately)
 	reply_to_email: 'REPLY',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -216,6 +216,56 @@ async function confirmSend(
 }
 
 /**
+ * Build the quoted-original text and HTML for a reply, matching Fastmail's reply
+ * button. Shared by `reply_to_email` (initial draft/send) and `update_draft`
+ * (re-appended when a reply draft's message is edited).
+ */
+function buildReplyQuotes(original: any): { quotedText: string; quotedHtml: string } {
+  const originalFrom = original.from?.[0];
+  const senderName = originalFrom?.name || originalFrom?.email || "Unknown";
+  const senderEmail = originalFrom?.email || "";
+
+  const receivedDate = new Date(original.receivedAt);
+  const dateStr = receivedDate.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  const timeStr = receivedDate.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+
+  const bodyValues = original.bodyValues as Record<string, { value: string }> | undefined;
+  const textPartId = original.textBody?.[0]?.partId;
+  const htmlPartId = original.htmlBody?.[0]?.partId;
+  const originalTextBody =
+    (textPartId && bodyValues?.[textPartId]?.value) || (bodyValues ? Object.values(bodyValues)[0]?.value : "") || "";
+
+  const quotedLines = originalTextBody
+    .split("\n")
+    .map((line: string) => `> ${line}`)
+    .join("\n");
+  const quotedText = `\n\nOn ${dateStr}, at ${timeStr}, ${senderName} <${senderEmail}> wrote:\n\n${quotedLines}`;
+
+  const originalHtmlBody = (htmlPartId && bodyValues?.[htmlPartId]?.value) || "";
+
+  const quotedContent =
+    originalHtmlBody ||
+    `<pre style="white-space: pre-wrap; font-family: inherit;">${originalTextBody.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</pre>`;
+
+  const quotedHtml = `
+<br><br>
+<div style="color: #666;">On ${dateStr}, at ${timeStr}, ${senderName} &lt;${senderEmail}&gt; wrote:</div>
+<blockquote type="cite" style="margin: 10px 0 0 0; padding: 0 0 0 10px; border-left: 2px solid #ccc;">
+${quotedContent}
+</blockquote>`;
+
+  return { quotedText, quotedHtml };
+}
+
+/**
  * Register all Fastmail MCP tools on the given server.
  *
  * @param server - McpServer instance to register tools on
@@ -579,46 +629,7 @@ export function registerAllTools(
           let quotedHtml = "";
 
           if (!excludeQuote) {
-            const originalFrom = original.from?.[0];
-            const senderName = originalFrom?.name || originalFrom?.email || "Unknown";
-            const senderEmail = originalFrom?.email || "";
-
-            const receivedDate = new Date(original.receivedAt);
-            const dateStr = receivedDate.toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            });
-            const timeStr = receivedDate.toLocaleTimeString("en-US", {
-              hour: "numeric",
-              minute: "2-digit",
-              hour12: true,
-            });
-
-            const bodyValues = original.bodyValues as Record<string, { value: string }> | undefined;
-            const textPartId = original.textBody?.[0]?.partId;
-            const htmlPartId = original.htmlBody?.[0]?.partId;
-            const originalTextBody =
-              (textPartId && bodyValues?.[textPartId]?.value) || (bodyValues ? Object.values(bodyValues)[0]?.value : "") || "";
-
-            const quotedLines = originalTextBody
-              .split("\n")
-              .map((line: string) => `> ${line}`)
-              .join("\n");
-            quotedText = `\n\nOn ${dateStr}, at ${timeStr}, ${senderName} <${senderEmail}> wrote:\n\n${quotedLines}`;
-
-            const originalHtmlBody = (htmlPartId && bodyValues?.[htmlPartId]?.value) || "";
-
-            const quotedContent =
-              originalHtmlBody ||
-              `<pre style="white-space: pre-wrap; font-family: inherit;">${originalTextBody.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</pre>`;
-
-            quotedHtml = `
-<br><br>
-<div style="color: #666;">On ${dateStr}, at ${timeStr}, ${senderName} &lt;${senderEmail}&gt; wrote:</div>
-<blockquote type="cite" style="margin: 10px 0 0 0; padding: 0 0 0 10px; border-left: 2px solid #ccc;">
-${quotedContent}
-</blockquote>`;
+            ({ quotedText, quotedHtml } = buildReplyQuotes(original));
           }
 
           const finalTextBody = body + quotedText;
@@ -684,6 +695,81 @@ ${quotedContent}
           const errorMessage = error instanceof Error ? error.message : String(error);
           return {
             content: [{ text: `Failed to create reply: ${errorMessage}`, type: "text" }],
+          };
+        }
+      },
+    );
+  }
+
+  if (shouldRegister("update_draft")) {
+    server.tool(
+      "update_draft",
+      "Edit the body of an existing draft, including reply drafts created by `reply_to_email`. JMAP email bodies are immutable, so this creates a replacement draft and deletes the old one — THE DRAFT ID CHANGES. Use the returned new draft ID for any further edits. Recipients, subject, sender identity, threading, and attachments are preserved automatically. For a reply draft, provide only your message text: the quoted original is re-derived and re-appended beneath it (from `replyToEmailId` if given, otherwise found via the draft's In-Reply-To header). Only messages in Drafts can be edited.",
+      {
+        draftId: z.string().describe("ID of the draft to edit."),
+        body: z.string().describe("The new message body (plain text). For a reply draft, provide only your message — the quoted original is re-appended automatically."),
+        htmlBody: z.string().optional().describe("New message body (HTML, optional). If not provided, plain text body is used."),
+        markdownBody: z
+          .string()
+          .optional()
+          .describe("New message body (Markdown, optional). Converted to HTML automatically. Takes precedence over htmlBody if both provided."),
+        replyToEmailId: z
+          .string()
+          .optional()
+          .describe("For reply drafts: ID of the email being replied to, used to regenerate the quoted original beneath your message. If omitted, the draft's In-Reply-To header is used to locate the source automatically."),
+        excludeQuote: z
+          .boolean()
+          .default(false)
+          .describe("If true, don't include a quoted original — your body becomes the entire draft. Default re-derives and keeps the quote for reply drafts."),
+      },
+      async ({ draftId, body, htmlBody, markdownBody, replyToEmailId, excludeQuote }) => {
+        try {
+          const client = ctx.getJmapClient();
+          const draft = await client.getEmailById(draftId);
+          if (!draft) {
+            return {
+              content: [{ text: `Error: Draft with ID '${draftId}' not found`, type: "text" }],
+            };
+          }
+
+          // Resolve the source email so the reply quote can be regenerated, unless
+          // the caller opted out. Prefer an explicit replyToEmailId; otherwise fall
+          // back to the draft's own In-Reply-To header.
+          let source: any = null;
+          if (!excludeQuote) {
+            if (replyToEmailId) {
+              source = await client.getEmailById(replyToEmailId);
+            } else if (draft.inReplyTo && draft.inReplyTo.length > 0) {
+              source = await client.getEmailByMessageId(draft.inReplyTo[0]);
+            }
+          }
+
+          const { quotedText, quotedHtml } = source ? buildReplyQuotes(source) : { quotedText: "", quotedHtml: "" };
+
+          const finalTextBody = body + quotedText;
+          const replyHtml = markdownBody ? await marked.parse(markdownBody) : htmlBody;
+          const finalHtmlBody = replyHtml
+            ? `<div>${replyHtml}</div>${quotedHtml}`
+            : `<div style="white-space: pre-wrap;">${body.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</div>${quotedHtml}`;
+
+          const newDraftId = await client.updateDraft({
+            draftId,
+            textBody: finalTextBody,
+            htmlBody: finalHtmlBody,
+          });
+
+          return {
+            content: [
+              {
+                text: `Draft updated. New draft ID: ${newDraftId}\nThe old ID (${draftId}) no longer exists — use the new ID for any further edits.${source ? "\nQuoted original preserved beneath your message." : ""}`,
+                type: "text",
+              },
+            ],
+          };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ text: `Failed to update draft: ${errorMessage}`, type: "text" }],
           };
         }
       },
@@ -1425,6 +1511,7 @@ ${quotedContent}
           "send_email",
           "send_copy",
           "create_draft",
+          "update_draft",
           "search_emails",
           "get_recent_emails",
           "get_inbox_updates",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -756,6 +756,7 @@ export function registerAllTools(
             draftId,
             textBody: finalTextBody,
             htmlBody: finalHtmlBody,
+            draft,
           });
 
           return {

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -289,8 +289,8 @@ describe('checkMcpPermissions — fail-closed', () => {
 });
 
 describe('TOOL_CATEGORIES completeness', () => {
-	it('maps all 37 tools', () => {
-		expect(Object.keys(TOOL_CATEGORIES).length).toBe(37);
+	it('maps all 38 tools', () => {
+		expect(Object.keys(TOOL_CATEGORIES).length).toBe(38);
 	});
 
 	it('has no empty categories', () => {


### PR DESCRIPTION
## Summary

Adds an `update_draft` tool so a draft's body (including reply drafts from `reply_to_email`) can be edited.

JMAP email bodies are **immutable** — the only server-mutable Email properties are `keywords` and `mailboxIds`. So "editing" a draft means creating a replacement with the new body and destroying the original, exactly how Fastmail's web client autosaves. **The draft ID changes**, and the new ID is returned.

## Changes

- **`src/jmap-client.ts`**
  - `updateDraft()` — guards that the target is a real draft (`$draft` keyword), preserves recipients/subject/from/threading/attachments (by blobId), then **creates the replacement first and only destroys the old draft after** — a failed create can never lose content; a failed destroy surfaces a recoverable duplicate rather than silent loss.
  - `getEmailByMessageId()` — locates a reply's source via a `header: ['Message-Id', ...]` query so the quote can be regenerated.
- **`src/tools.ts`** — new `update_draft` MCP tool; extracted a shared `buildReplyQuotes()` helper (reused by `reply_to_email`, behavior unchanged). For reply drafts the quoted original is re-derived from `replyToEmailId`, or auto-discovered via the draft's `In-Reply-To` header.
- **`src/permissions.ts`** — `update_draft` → `DRAFT` category (delegate-allowed, never sends).
- **CLI** — `fastmail email update-draft <draftId>` command + skill docs.
- **OpenClaw plugin** — `fastmail_update_draft` tool; version bump **3.1.5 → 3.2.0**.
- **Docs** — README / AGENTS / SKILL tool lists and counts updated.

## Verification

- `npm run type-check` clean (root + plugin); `npm run test` 59/59.
- **End-to-end against the live account**: created a reply draft, edited it via the **auto-discovery path** (no `replyToEmailId`), confirmed the quote was regenerated, `to`/subject/`inReplyTo`/`references`/`threadId` preserved, and the old draft destroyed with no duplicate. Test draft cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)