### PR TITLE
security: harden OAuth, permissions, and served HTML (audit 2026-07-20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,7 +509,8 @@ Durable memory promoted from `~/.claude/projects/-Users-omarshahine-GitHub-fastm
 
 ### Wrangler Custom Domains
 - Custom domain configured in gitignored `wrangler.jsonc` via `routes` array with `custom_domain: true`
-- Adding `routes` causes wrangler to default `workers_dev` and `preview_urls` to `false` — set both to `true` explicitly
+- Adding `routes` causes wrangler to default `workers_dev` and `preview_urls` to `false`
+- **Keep both `false`** (set explicitly as of the 2026-07-20 security audit, issue #52). Serving only via the custom domain preserves any WAF / rate-limit / hostname-scoped Access policy bound to that hostname; `*.workers.dev` and preview URLs bypass it.
 
 ### MCP Streamable HTTP uses SSE, not plain JSON
 - The `@anthropic-ai/agents` SDK returns `text/event-stream` for ALL MCP responses, including `tools/list`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,10 @@ ALLOWED_USERS=user1@example.com,user2@example.com
 |----------|-------------|
 | `ACCESS_TEAM_NAME` | Cloudflare Zero Trust team name |
 | `ALLOWED_USERS` | Comma-separated list of allowed email addresses |
+| `ALLOWED_REDIRECT_HOSTS` | Optional. Comma-separated extra hostnames permitted as OAuth `redirect_uri` targets. Loopback and the worker's own origin are always allowed. Defaults to `claude.ai,claude.com,anthropic.com` when unset. **Setting this replaces the defaults** — include them if you still need them. |
+| `ACTION_ALLOWED_ORIGINS` | Optional. Comma-separated browser origins allowed to call `/api/action/*`. Unset means `*`, which is required if the reading-digest page is opened from a local `file://` URL (`Origin: null`). |
+
+> **Security note:** `workers_dev` and `preview_urls` are set to `false` so the worker is reachable only via the custom domain. Turning them on re-exposes `*.workers.dev` and per-version preview URLs, which bypass any WAF / rate-limit / hostname-scoped Access policy bound to the custom hostname.
 
 ## KV Keys
 
@@ -249,7 +253,7 @@ ALLOWED_USERS=user1@example.com,user2@example.com
 | `state:{id}` | OAuth state (client_id, redirect_uri, PKCE, etc.) | 10 min |
 | `code:{id}` | Auth code (user info, PKCE challenge) | 1 min |
 | `token:{hash}` | Access token info (user_id, scope) | 30 days |
-| `client:{id}` | Registered client info | None |
+| `client:{id}` | Registered client info | 90 days |
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ Add `ACCESS_TEAM_NAME` and `ALLOWED_USERS` as plaintext vars in your `wrangler.j
 - **ACCESS_TEAM_NAME**: Your Cloudflare Zero Trust team name (the subdomain before `.cloudflareaccess.com`)
 - **ALLOWED_USERS**: Comma-separated list of email addresses allowed to access the server
 
+Two optional vars tighten things further:
+
+- **ALLOWED_REDIRECT_HOSTS**: Extra hostnames permitted as OAuth `redirect_uri` targets. Loopback (native/CLI clients) and the worker's own origin are always allowed; everything else must be an `https` host on this list. Defaults to `claude.ai,claude.com,anthropic.com`. Setting it **replaces** the defaults rather than adding to them.
+- **ACTION_ALLOWED_ORIGINS**: Browser origins allowed to call the signed `/api/action/*` endpoints. Leave unset (`*`) if you open the reading-digest page from a local file, which sends `Origin: null`.
+
 For local development, also add these to `.dev.vars` (gitignored).
 
 > **Warning**: Deploying without the `vars` section in `wrangler.jsonc` will wipe all dashboard-set plaintext vars. Always keep `vars` in your local config.

--- a/src/action-urls.ts
+++ b/src/action-urls.ts
@@ -66,13 +66,22 @@ export async function verifyAction(
 	// Check expiry first
 	if (Date.now() / 1000 > exp) return false;
 
+	// Reject anything that isn't a well-formed HMAC-SHA256 hex digest before
+	// decoding — hexToBuffer would otherwise produce NaN bytes for junk input.
+	if (!/^[0-9a-f]{64}$/i.test(sig)) return false;
+
 	const key = await importKey(signingKey);
 	const payload = buildPayload(action, emailId, mid, exp);
-	const expected = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
 
-	// Constant-time comparison via verify
-	return crypto.subtle.verify('HMAC', key, expected, new TextEncoder().encode(bufferToHex(expected)).buffer as ArrayBuffer)
-		.then(() => sig === bufferToHex(expected));
+	// Verify the CALLER's signature against the payload. crypto.subtle.verify
+	// does the digest comparison internally in constant time, so no signature
+	// bytes are compared with a short-circuiting JS `===`.
+	return crypto.subtle.verify(
+		'HMAC',
+		key,
+		hexToBuffer(sig),
+		new TextEncoder().encode(payload),
+	);
 }
 
 // ─── URL Generation ──────────────────────────────────────────────────────────

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -8,5 +8,17 @@ declare namespace Cloudflare {
     LOADER: WorkerLoader;
     /** Set to "true" to enable MCP elicitation-based send confirmation dialogs. Defaults to off. */
     ENABLE_SEND_CONFIRMATION?: string;
+    /**
+     * Comma-separated extra hostnames permitted as OAuth redirect_uri targets,
+     * beyond loopback and the worker's own origin. Defaults to the Anthropic/
+     * Claude domains when unset. See isAllowedRedirectUri in oauth-utils.ts.
+     */
+    ALLOWED_REDIRECT_HOSTS?: string;
+    /**
+     * Comma-separated browser origins allowed to call the HMAC-signed
+     * /api/action/* endpoints. Unset means "*" (needed when the reading-digest
+     * page is opened from a local file:// URL, which sends Origin: null).
+     */
+    ACTION_ALLOWED_ORIGINS?: string;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -354,18 +354,36 @@ app.get("/download/:token", async (c) => {
 // These endpoints are called directly from the reading-digest HTML page.
 // Auth is via HMAC signature in the URL — no Bearer token or CF Access needed.
 
-function corsHeaders(): Record<string, string> {
+// These endpoints carry no ambient credentials — the capability IS the signed,
+// single-use URL — so CORS is not what protects them. Still, ACTION_ALLOWED_ORIGINS
+// (comma-separated) narrows which browser origins may read the response. When it
+// is unset we fall back to "*", which keeps the locally-opened digest page
+// (file:// → "Origin: null") working.
+function corsHeaders(env: Env, requestOrigin: string | null): Record<string, string> {
+  const configured = (env.ACTION_ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  let allowOrigin = "*";
+  if (configured.length > 0) {
+    // Echo back only an origin we recognize; otherwise name the primary one so
+    // a disallowed origin is refused by the browser rather than silently allowed.
+    allowOrigin = requestOrigin && configured.includes(requestOrigin) ? requestOrigin : configured[0];
+  }
+
   return {
-    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Origin": allowOrigin,
     "Access-Control-Allow-Methods": "POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     "Content-Type": "application/json",
+    Vary: "Origin",
   };
 }
 
 // CORS preflight (defensive — simple POST won't trigger preflight, but browsers vary)
 app.options("/api/action/:action/:emailId", (c) => {
-  return new Response(null, { status: 204, headers: corsHeaders() });
+  return new Response(null, { status: 204, headers: corsHeaders(c.env, c.req.header("Origin") ?? null) });
 });
 
 // Execute email action (archive or delete)
@@ -376,33 +394,34 @@ app.post("/api/action/:action/:emailId", async (c) => {
   const expStr = c.req.query("exp") || "0";
   const sig = c.req.query("sig") || "";
   const exp = parseInt(expStr, 10);
+  const cors = corsHeaders(c.env, c.req.header("Origin") ?? null);
 
   // Validate action type
   if (action !== "archive" && action !== "delete") {
-    return c.json({ ok: false, error: "Invalid action. Must be 'archive' or 'delete'." }, { status: 400, headers: corsHeaders() });
+    return c.json({ ok: false, error: "Invalid action. Must be 'archive' or 'delete'." }, { status: 400, headers: cors });
   }
 
   // Archive requires a mailbox ID
   if (action === "archive" && !mid) {
-    return c.json({ ok: false, error: "Archive action requires 'mid' (mailbox ID) parameter." }, { status: 400, headers: corsHeaders() });
+    return c.json({ ok: false, error: "Archive action requires 'mid' (mailbox ID) parameter." }, { status: 400, headers: cors });
   }
 
   // Verify HMAC signature + expiry
   const signingKey = c.env.ACTION_SIGNING_KEY;
   if (!signingKey) {
     console.error("[action] ACTION_SIGNING_KEY not configured");
-    return c.json({ ok: false, error: "Server misconfigured." }, { status: 500, headers: corsHeaders() });
+    return c.json({ ok: false, error: "Server misconfigured." }, { status: 500, headers: cors });
   }
 
   const valid = await verifyAction(action, emailId, mid, exp, sig, signingKey);
   if (!valid) {
-    return c.json({ ok: false, error: "Invalid or expired signature." }, { status: 403, headers: corsHeaders() });
+    return c.json({ ok: false, error: "Invalid or expired signature." }, { status: 403, headers: cors });
   }
 
   // Single-use enforcement: consume the nonce (reject if already used)
   const nonce = await c.env.OAUTH_KV.get(nonceKey(sig));
   if (!nonce) {
-    return c.json({ ok: false, error: "Action URL already used." }, { status: 409, headers: corsHeaders() });
+    return c.json({ ok: false, error: "Action URL already used." }, { status: 409, headers: cors });
   }
   await c.env.OAUTH_KV.delete(nonceKey(sig));
 
@@ -418,11 +437,11 @@ app.post("/api/action/:action/:emailId", async (c) => {
       await client.deleteEmail(emailId);
     }
 
-    return c.json({ ok: true, action, emailId }, { status: 200, headers: corsHeaders() });
+    return c.json({ ok: true, action, emailId }, { status: 200, headers: cors });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`[action] Failed to ${action} email ${emailId}: ${message}`);
-    return c.json({ ok: false, error: `Failed to ${action} email: ${message}` }, { status: 502, headers: corsHeaders() });
+    return c.json({ ok: false, error: `Failed to ${action} email: ${message}` }, { status: 502, headers: cors });
   }
 });
 

--- a/src/oauth-handler.ts
+++ b/src/oauth-handler.ts
@@ -11,12 +11,14 @@ import {
 	getExpiresAt,
 	isExpired,
 	isUserAllowed,
+	isAllowedRedirectUri,
 	verifyCodeChallenge,
 	validateRefreshToken,
 	verifyAccessIdToken,
 	STATE_TTL_SECONDS,
 	CODE_TTL_SECONDS,
 	TOKEN_TTL_SECONDS,
+	CLIENT_TTL_SECONDS,
 	DEFAULT_SCOPE,
 	getAccessBaseUrl,
 	type OAuthStateData,
@@ -78,7 +80,7 @@ export function handleOAuthDiscovery(url: URL): Response {
 		response_modes_supported: ['query'],
 		grant_types_supported: ['authorization_code', 'refresh_token'],
 		token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
-		code_challenge_methods_supported: ['S256', 'plain'],
+		code_challenge_methods_supported: ['S256'],
 		service_documentation: url.origin,
 		logo_uri: `${url.origin}/favicon.png`,
 	};
@@ -121,64 +123,39 @@ export async function handleAuthorize(request: Request, env: Env, url: URL): Pro
 		return new Response('Invalid response_type, only "code" is supported', { status: 400 });
 	}
 
-	// Validate PKCE if provided
-	if (codeChallenge && codeChallengeMethod !== 'S256' && codeChallengeMethod !== 'plain') {
-		return new Response('Invalid code_challenge_method', { status: 400 });
+	// PKCE: only S256 is accepted. `plain` is rejected because it offers no
+	// protection against an intercepted authorization code.
+	if (codeChallenge && codeChallengeMethod !== 'S256') {
+		return new Response('Only code_challenge_method=S256 is supported', { status: 400 });
 	}
 
-	// Validate redirect URI (allow HTTPS, localhost, OOB, or custom schemes for native apps)
+	// Validate redirect URI against the host allowlist. This is enforced for
+	// ALL clients — registered or not — so open dynamic registration can never
+	// whitelist an attacker-controlled origin and phish an auth code to it
+	// (the unregistered→any-https fallback that made this exploitable is gone).
 	const isOOBUri = redirectUri === 'urn:ietf:wg:oauth:2.0:oob' || redirectUri.startsWith('oob:');
+	if (!isAllowedRedirectUri(redirectUri, url.origin, env.ALLOWED_REDIRECT_HOSTS)) {
+		return new Response('Invalid redirect_uri', { status: 400 });
+	}
 	if (!isOOBUri) {
-		try {
-			const redirectUrl = new URL(redirectUri);
-			const proto = redirectUrl.protocol;
-
-			// Per RFC 8252 §7.3, loopback redirect URIs for native apps must match on
-			// scheme, host, and path — but the port MUST be ignored because native apps
-			// bind to ephemeral ports.
-			const isLoopback =
-				(redirectUrl.hostname === 'localhost' || redirectUrl.hostname === '127.0.0.1') &&
-				(proto === 'http:' || proto === 'https:');
-
-			// Look up dynamically-registered client to validate redirect_uri
-			const clientJson = await env.OAUTH_KV.get(`client:${clientId}`);
-			if (clientJson) {
-				// Client was dynamically registered — validate redirect_uri
-				const clientData = JSON.parse(clientJson) as OAuthClientData;
-				const exactMatch = clientData.redirect_uris.includes(redirectUri);
-
-				// For loopback URIs, match scheme + host + path, ignoring port (RFC 8252 §7.3)
-				const loopbackMatch = isLoopback && clientData.redirect_uris.some((registered) => {
-					try {
-						const regUrl = new URL(registered);
-						const regIsLoopback =
-							(regUrl.hostname === 'localhost' || regUrl.hostname === '127.0.0.1') &&
-							(regUrl.protocol === 'http:' || regUrl.protocol === 'https:');
-						return regIsLoopback &&
-							regUrl.protocol === redirectUrl.protocol &&
-							regUrl.hostname === redirectUrl.hostname &&
-							regUrl.pathname === redirectUrl.pathname;
-					} catch {
-						return false;
-					}
-				});
-
-				if (!exactMatch && !loopbackMatch) {
-					return new Response('Invalid redirect_uri', { status: 400 });
-				}
-			} else {
-				// No registration record — fall back to scheme validation
-				// Allow https, localhost HTTP, and custom schemes for native apps (RFC 8252)
-				const isHttps = proto === 'https:';
-				const isCustomScheme = proto !== 'http:' && proto !== 'https:';
-
-				if (!isHttps && !isLoopback && !isCustomScheme) {
-					return new Response('Invalid redirect_uri', { status: 400 });
-				}
+		// For a pre-registered client, additionally require membership in its
+		// registered redirect_uris. Loopback URIs match on scheme+host+path but
+		// ignore the port, because native/CLI clients bind an ephemeral port at
+		// runtime that differs from the one registered (RFC 8252 §7.3).
+		const clientJson = await env.OAUTH_KV.get(`client:${clientId}`);
+		if (clientJson) {
+			const clientData = JSON.parse(clientJson) as OAuthClientData;
+			if (!redirectUriMatchesRegistered(redirectUri, clientData.redirect_uris)) {
+				return new Response('Invalid redirect_uri', { status: 400 });
 			}
-		} catch {
-			return new Response('Invalid redirect_uri', { status: 400 });
 		}
+	}
+
+	// Require PKCE (S256) for every non-OOB flow. Without this, an intercepted
+	// authorization code alone is enough to mint a full-scope token. OOB is
+	// exempt because its code is shown on-screen and never auto-redirected.
+	if (!isOOBUri && (!codeChallenge || codeChallengeMethod !== 'S256')) {
+		return new Response('PKCE (code_challenge with S256) is required for non-OOB flows', { status: 400 });
 	}
 
 	// Generate state and store OAuth parameters in KV
@@ -430,13 +407,25 @@ export async function handleToken(request: Request, env: Env): Promise<Response>
 		return jsonError('invalid_grant', 'redirect_uri mismatch', 400);
 	}
 
-	// Validate PKCE if code challenge was provided
+	// Defense in depth: re-check the bound redirect_uri against the host
+	// allowlist at token time, so a code minted before an allowlist change
+	// (or via any future authorize-side gap) still cannot be redeemed for a
+	// token destined to a disallowed origin.
+	if (!isAllowedRedirectUri(authCode.redirect_uri, new URL(request.url).origin, env.ALLOWED_REDIRECT_HOSTS)) {
+		return jsonError('invalid_grant', 'redirect_uri not permitted', 400);
+	}
+
+	// Validate PKCE if code challenge was provided. Only S256 is accepted —
+	// `plain` offers no protection against an intercepted code.
 	if (authCode.code_challenge) {
+		if (authCode.code_challenge_method !== 'S256') {
+			return jsonError('invalid_grant', 'Only S256 PKCE is supported', 400);
+		}
 		if (!body.code_verifier) {
 			return jsonError('invalid_request', 'Missing code_verifier for PKCE', 400);
 		}
 
-		const isValid = await verifyCodeChallenge(body.code_verifier, authCode.code_challenge, authCode.code_challenge_method || 'plain');
+		const isValid = await verifyCodeChallenge(body.code_verifier, authCode.code_challenge, 'S256');
 		if (!isValid) {
 			return jsonError('invalid_grant', 'Invalid code_verifier', 400);
 		}
@@ -579,6 +568,15 @@ export async function handleRegister(request: Request, env: Env): Promise<Respon
 		return jsonError('invalid_request', 'Missing or invalid redirect_uris', 400);
 	}
 
+	// Reject registration outright if any redirect_uri is outside the host
+	// allowlist, so unauthenticated registration cannot stage a phishing target.
+	const workerOrigin = new URL(request.url).origin;
+	for (const uri of body.redirect_uris) {
+		if (typeof uri !== 'string' || !isAllowedRedirectUri(uri, workerOrigin, env.ALLOWED_REDIRECT_HOSTS)) {
+			return jsonError('invalid_redirect_uri', `redirect_uri not permitted: ${uri}`, 400);
+		}
+	}
+
 	// Generate client credentials
 	const clientId = generateState();
 
@@ -588,8 +586,11 @@ export async function handleRegister(request: Request, env: Env): Promise<Respon
 		redirect_uris: body.redirect_uris,
 	};
 
-	// Store in KV (no expiration for clients)
-	await env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(clientData));
+	// TTL-bounded so open, unauthenticated registration cannot grow OAUTH_KV
+	// without limit. Clients re-register transparently once a record lapses.
+	await env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(clientData), {
+		expirationTtl: CLIENT_TTL_SECONDS,
+	});
 
 	return new Response(
 		JSON.stringify({
@@ -604,11 +605,80 @@ export async function handleRegister(request: Request, env: Env): Promise<Respon
 	);
 }
 
+// Whether a requested redirect_uri is covered by a client's registered set.
+// Exact string match, except loopback URIs (localhost/127.0.0.1) match on
+// scheme+host+path while ignoring the port, per RFC 8252 §7.3 — native/CLI
+// clients bind an ephemeral port that won't equal the registered one.
+function redirectUriMatchesRegistered(redirectUri: string, registered: string[]): boolean {
+	if (registered.includes(redirectUri)) return true;
+
+	let reqUrl: URL;
+	try {
+		reqUrl = new URL(redirectUri);
+	} catch {
+		return false;
+	}
+	const isLoopback =
+		(reqUrl.hostname === 'localhost' || reqUrl.hostname === '127.0.0.1') &&
+		(reqUrl.protocol === 'http:' || reqUrl.protocol === 'https:');
+	if (!isLoopback) return false;
+
+	return registered.some((entry) => {
+		try {
+			const regUrl = new URL(entry);
+			const regIsLoopback =
+				(regUrl.hostname === 'localhost' || regUrl.hostname === '127.0.0.1') &&
+				(regUrl.protocol === 'http:' || regUrl.protocol === 'https:');
+			return (
+				regIsLoopback &&
+				regUrl.protocol === reqUrl.protocol &&
+				regUrl.hostname === reqUrl.hostname &&
+				regUrl.pathname === reqUrl.pathname
+			);
+		} catch {
+			return false;
+		}
+	});
+}
+
 function jsonError(error: string, description: string, status: number): Response {
 	return new Response(JSON.stringify({ error, error_description: description }), {
 		status,
 		headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', Pragma: 'no-cache' },
 	});
+}
+
+// Security headers for every HTML page this worker serves. These pages can
+// carry a bearer token or authorization code, so:
+//  - Referrer-Policy stops the URL leaking to any third party via Referer
+//  - CSP denies by default; there is no connect/form/frame surface at all, so
+//    even a hypothetical injection has no network path to exfiltrate the token
+//  - scripts run only under a per-response nonce (no 'unsafe-inline')
+function htmlSecurityHeaders(nonce?: string): Record<string, string> {
+	const scriptSrc = nonce ? `'nonce-${nonce}'` : "'none'";
+	return {
+		'Content-Type': 'text/html; charset=utf-8',
+		'Cache-Control': 'no-store',
+		'Referrer-Policy': 'no-referrer',
+		'X-Content-Type-Options': 'nosniff',
+		'X-Frame-Options': 'DENY',
+		'Content-Security-Policy': [
+			"default-src 'none'",
+			"style-src 'unsafe-inline'",
+			`script-src ${scriptSrc}`,
+			"img-src 'self'",
+			"base-uri 'none'",
+			"form-action 'none'",
+			"frame-ancestors 'none'",
+		].join('; '),
+	};
+}
+
+// Per-response CSP nonce.
+function generateNonce(): string {
+	const bytes = new Uint8Array(16);
+	crypto.getRandomValues(bytes);
+	return btoa(String.fromCharCode(...bytes)).replace(/=+$/, '');
 }
 
 // Escape HTML special characters to prevent XSS
@@ -624,6 +694,7 @@ function escapeHtml(str: string | null | undefined): string {
 
 // Render OOB page for explicit headless/SSH OAuth flow (no redirect attempt)
 function renderOOBPage(authCode: string, clientState: string | null, _unused: null): Response {
+	const nonce = generateNonce();
 	const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -737,7 +808,7 @@ function renderOOBPage(authCode: string, clientState: string | null, _unused: nu
 		<div class="code-label">Authorization Code</div>
 		<div class="code-box">
 			<code id="authCode">${authCode}</code>
-			<button class="copy-btn" onclick="copyCode()">Copy</button>
+			<button class="copy-btn" id="copyBtn">Copy</button>
 		</div>
 
 		<div class="instructions">
@@ -752,11 +823,11 @@ function renderOOBPage(authCode: string, clientState: string | null, _unused: nu
 		${clientState ? `<div class="state-info">State: ${escapeHtml(clientState)}</div>` : ''}
 	</div>
 
-	<script>
-		function copyCode() {
+	<script nonce="${nonce}">
+		document.getElementById('copyBtn').addEventListener('click', () => {
 			const code = document.getElementById('authCode').textContent;
 			navigator.clipboard.writeText(code).then(() => {
-				const btn = document.querySelector('.copy-btn');
+				const btn = document.getElementById('copyBtn');
 				btn.textContent = 'Copied!';
 				btn.classList.add('copied');
 				setTimeout(() => {
@@ -764,17 +835,14 @@ function renderOOBPage(authCode: string, clientState: string | null, _unused: nu
 					btn.classList.remove('copied');
 				}, 2000);
 			});
-		}
+		});
 	</script>
 </body>
 </html>`;
 
 	return new Response(html, {
 		status: 200,
-		headers: {
-			'Content-Type': 'text/html; charset=utf-8',
-			'Cache-Control': 'no-store',
-		},
+		headers: htmlSecurityHeaders(nonce),
 	});
 }
 
@@ -925,6 +993,7 @@ export async function handleGetTokenCallback(request: Request, env: Env, url: UR
 }
 
 function renderDirectTokenSuccess(token: string, email: string, expiry: string, origin: string): Response {
+	const nonce = generateNonce();
 	const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1036,7 +1105,7 @@ function renderDirectTokenSuccess(token: string, email: string, expiry: string, 
 			<div class="section-title">Your Access Token</div>
 			<div class="token-box">
 				<code id="token">${token}</code>
-				<button class="copy-btn" onclick="copyToken()">Copy</button>
+				<button class="copy-btn" id="copyBtn">Copy</button>
 			</div>
 		</div>
 
@@ -1055,22 +1124,22 @@ function renderDirectTokenSuccess(token: string, email: string, expiry: string, 
 		<p class="expiry">Token expires: ${expiry}</p>
 	</div>
 
-	<script>
-		function copyToken() {
+	<script nonce="${nonce}">
+		document.getElementById('copyBtn').addEventListener('click', () => {
 			navigator.clipboard.writeText(document.getElementById('token').textContent).then(() => {
-				const btn = document.querySelector('.copy-btn');
+				const btn = document.getElementById('copyBtn');
 				btn.textContent = 'Copied!';
 				btn.classList.add('copied');
 				setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 2000);
 			});
-		}
+		});
 	</script>
 </body>
 </html>`;
 
 	return new Response(html, {
 		status: 200,
-		headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' },
+		headers: htmlSecurityHeaders(nonce),
 	});
 }
 
@@ -1140,6 +1209,6 @@ function renderDirectTokenError(message: string): Response {
 
 	return new Response(html, {
 		status: 400,
-		headers: { 'Content-Type': 'text/html; charset=utf-8' },
+		headers: htmlSecurityHeaders(),
 	});
 }

--- a/src/oauth-handler.ts
+++ b/src/oauth-handler.ts
@@ -12,6 +12,7 @@ import {
 	isExpired,
 	isUserAllowed,
 	isAllowedRedirectUri,
+	isLoopbackHost,
 	verifyCodeChallenge,
 	validateRefreshToken,
 	verifyAccessIdToken,
@@ -606,9 +607,18 @@ export async function handleRegister(request: Request, env: Env): Promise<Respon
 }
 
 // Whether a requested redirect_uri is covered by a client's registered set.
-// Exact string match, except loopback URIs (localhost/127.0.0.1) match on
-// scheme+host+path while ignoring the port, per RFC 8252 §7.3 — native/CLI
-// clients bind an ephemeral port that won't equal the registered one.
+// Exact string match, except loopback URIs match on scheme+host+path while
+// ignoring the port, per RFC 8252 §7.3 — native/CLI clients bind an ephemeral
+// port that won't equal the one they registered.
+//
+// Loopback detection MUST come from the shared isLoopbackHost (IPv4, IPv6, and
+// localhost). An inline copy here previously omitted IPv6, so a client that
+// registered http://[::1]/callback passed the global allowlist but was then
+// rejected by this matcher.
+function isLoopbackUrl(u: URL): boolean {
+	return isLoopbackHost(u.hostname) && (u.protocol === 'http:' || u.protocol === 'https:');
+}
+
 function redirectUriMatchesRegistered(redirectUri: string, registered: string[]): boolean {
 	if (registered.includes(redirectUri)) return true;
 
@@ -618,19 +628,13 @@ function redirectUriMatchesRegistered(redirectUri: string, registered: string[])
 	} catch {
 		return false;
 	}
-	const isLoopback =
-		(reqUrl.hostname === 'localhost' || reqUrl.hostname === '127.0.0.1') &&
-		(reqUrl.protocol === 'http:' || reqUrl.protocol === 'https:');
-	if (!isLoopback) return false;
+	if (!isLoopbackUrl(reqUrl)) return false;
 
 	return registered.some((entry) => {
 		try {
 			const regUrl = new URL(entry);
-			const regIsLoopback =
-				(regUrl.hostname === 'localhost' || regUrl.hostname === '127.0.0.1') &&
-				(regUrl.protocol === 'http:' || regUrl.protocol === 'https:');
 			return (
-				regIsLoopback &&
+				isLoopbackUrl(regUrl) &&
 				regUrl.protocol === reqUrl.protocol &&
 				regUrl.hostname === reqUrl.hostname &&
 				regUrl.pathname === reqUrl.pathname

--- a/src/oauth-utils.ts
+++ b/src/oauth-utils.ts
@@ -21,7 +21,13 @@ export const DEFAULT_SCOPE = 'mcp:read mcp:write';
 // via the ALLOWED_REDIRECT_HOSTS env var (comma-separated hostnames).
 const DEFAULT_REDIRECT_HOSTS = ['claude.ai', 'claude.com', 'anthropic.com'];
 
-function isLoopbackHost(hostname: string): boolean {
+/**
+ * Loopback hosts for native/CLI clients. Exported so every redirect_uri check
+ * shares one definition — the allowlist and the registered-URI matcher must
+ * agree on what counts as loopback, or an IPv6 client passes one and fails the
+ * other. `URL.hostname` yields the bracketed form for IPv6, so accept both.
+ */
+export function isLoopbackHost(hostname: string): boolean {
 	return (
 		hostname === 'localhost' ||
 		hostname === '127.0.0.1' ||

--- a/src/oauth-utils.ts
+++ b/src/oauth-utils.ts
@@ -10,7 +10,77 @@
 export const STATE_TTL_SECONDS = 600; // 10 minutes
 export const CODE_TTL_SECONDS = 60; // 1 minute
 export const TOKEN_TTL_SECONDS = 86400 * 30; // 30 days
+export const CLIENT_TTL_SECONDS = 86400 * 90; // 90 days — bounds unauthenticated /register growth
 export const DEFAULT_SCOPE = 'mcp:read mcp:write';
+
+// Redirect URIs are constrained to a host allowlist at authorize, token, and
+// registration time so that open, unauthenticated dynamic client registration
+// cannot be used to phish an auth code to an attacker-controlled origin.
+// Loopback (native CLI clients) and the worker's own origin are always allowed;
+// hosted connectors default to the Anthropic/Claude domains and can be extended
+// via the ALLOWED_REDIRECT_HOSTS env var (comma-separated hostnames).
+const DEFAULT_REDIRECT_HOSTS = ['claude.ai', 'claude.com', 'anthropic.com'];
+
+function isLoopbackHost(hostname: string): boolean {
+	return (
+		hostname === 'localhost' ||
+		hostname === '127.0.0.1' ||
+		hostname === '::1' ||
+		hostname === '[::1]'
+	);
+}
+
+/**
+ * Whether a client redirect_uri may receive an auth code. This is enforced for
+ * ALL clients (registered or not) — registration alone can never whitelist a
+ * host.
+ *
+ * Allowed:
+ *  - OOB (code is shown on-screen, never auto-redirected)
+ *  - http(s) loopback on any port (native/CLI clients)
+ *  - the worker's own origin
+ *  - https on a host in the allowlist (exact or subdomain match)
+ * Everything else (arbitrary external https, custom app schemes) is rejected.
+ */
+export function isAllowedRedirectUri(
+	redirectUri: string,
+	workerOrigin: string,
+	allowedHostsCsv?: string | null
+): boolean {
+	if (redirectUri === 'urn:ietf:wg:oauth:2.0:oob' || redirectUri.startsWith('oob:')) {
+		return true;
+	}
+
+	let u: URL;
+	try {
+		u = new URL(redirectUri);
+	} catch {
+		return false;
+	}
+
+	const proto = u.protocol;
+	if ((proto === 'http:' || proto === 'https:') && isLoopbackHost(u.hostname)) {
+		return true;
+	}
+
+	// Beyond loopback, only https is permitted.
+	if (proto !== 'https:') return false;
+
+	try {
+		if (u.host === new URL(workerOrigin).host) return true;
+	} catch {
+		// workerOrigin malformed — fall through to allowlist check
+	}
+
+	const extraHosts = (allowedHostsCsv || '')
+		.split(',')
+		.map((h) => h.trim().toLowerCase())
+		.filter(Boolean);
+	const hosts = extraHosts.length > 0 ? extraHosts : DEFAULT_REDIRECT_HOSTS;
+
+	const host = u.hostname.toLowerCase();
+	return hosts.some((h) => host === h || host.endsWith(`.${h}`));
+}
 
 // Build Access base URL from team name (set via ACCESS_TEAM_NAME env var)
 export function getAccessBaseUrl(teamName: string): string {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -127,9 +127,13 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 let cachedConfig: PermissionsConfig | null = null;
 let cachedAt = 0;
 
+// Fails CLOSED: with no config in KV, every identity resolves to the least
+// privileged role. Granting admin requires an explicit `users` entry — a
+// missing, deleted, or never-seeded `config:permissions` key must never
+// silently hand out full send/delete rights to everyone in ALLOWED_USERS.
 const DEFAULT_CONFIG: PermissionsConfig = {
 	users: {},
-	default_role: 'admin',
+	default_role: 'delegate',
 	default_disabled_categories: [],
 };
 
@@ -140,7 +144,19 @@ export async function getPermissionsConfig(kv: KVNamespace): Promise<Permissions
 		return cachedConfig;
 	}
 
-	const data = await kv.get<PermissionsConfig>('config:permissions', 'json');
+	let data: PermissionsConfig | null;
+	try {
+		data = await kv.get<PermissionsConfig>('config:permissions', 'json');
+	} catch (e) {
+		// A KV read FAILURE is not the same as a KV MISS. Caching the fallback
+		// here would pin it for the whole 5-minute window on one transient
+		// blip, so serve fail-closed for this request only and retry on the
+		// next one.
+		console.error(`[permissions] KV read failed — failing closed for this request: ${e}`);
+		return DEFAULT_CONFIG;
+	}
+
+	// A genuine miss (key absent) is cacheable: the fallback is fail-closed.
 	cachedConfig = data ?? DEFAULT_CONFIG;
 	cachedAt = now;
 	return cachedConfig;

--- a/src/prompt-guard.ts
+++ b/src/prompt-guard.ts
@@ -13,8 +13,17 @@
  * 3. Content annotation: Adds warnings when suspicious patterns are detected
  */
 
-// Delimiter tokens for spotlighting - randomized per-session to prevent attacker adaptation
-const SESSION_TOKEN = Math.random().toString(36).substring(2, 8).toUpperCase();
+// Delimiter tokens for spotlighting - randomized per-session to prevent attacker
+// adaptation. Uses a CSPRNG so the token can't be predicted from other observed
+// output, which Math.random() would not guarantee.
+function randomSessionToken(): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const bytes = new Uint8Array(6);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => alphabet[b % alphabet.length]).join('');
+}
+
+const SESSION_TOKEN = randomSessionToken();
 const UNTRUSTED_START = `[UNTRUSTED_EXTERNAL_DATA_${SESSION_TOKEN}]`;
 const UNTRUSTED_END = `[/UNTRUSTED_EXTERNAL_DATA_${SESSION_TOKEN}]`;
 

--- a/test/action-urls.test.ts
+++ b/test/action-urls.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { signAction, verifyAction } from '../src/action-urls';
+
+// 256-bit key as hex, matching what ACTION_SIGNING_KEY holds.
+const KEY = 'a'.repeat(64);
+const OTHER_KEY = 'b'.repeat(64);
+
+function futureExp(): number {
+	return Math.floor(Date.now() / 1000) + 3600;
+}
+
+describe('signAction / verifyAction', () => {
+	it('round-trips a valid signature', async () => {
+		const exp = futureExp();
+		const sig = await signAction('archive', 'email-1', 'mailbox-1', exp, KEY);
+
+		await expect(verifyAction('archive', 'email-1', 'mailbox-1', exp, sig, KEY)).resolves.toBe(true);
+	});
+
+	it('produces a 64-char hex HMAC-SHA256 digest', async () => {
+		const sig = await signAction('delete', 'email-1', '', futureExp(), KEY);
+		expect(sig).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('rejects a tampered action, emailId, mailbox, or expiry', async () => {
+		const exp = futureExp();
+		const sig = await signAction('archive', 'email-1', 'mailbox-1', exp, KEY);
+
+		await expect(verifyAction('delete', 'email-1', 'mailbox-1', exp, sig, KEY)).resolves.toBe(false);
+		await expect(verifyAction('archive', 'email-2', 'mailbox-1', exp, sig, KEY)).resolves.toBe(false);
+		await expect(verifyAction('archive', 'email-1', 'mailbox-2', exp, sig, KEY)).resolves.toBe(false);
+		await expect(verifyAction('archive', 'email-1', 'mailbox-1', exp + 1, sig, KEY)).resolves.toBe(false);
+	});
+
+	it('rejects a signature made with a different key', async () => {
+		const exp = futureExp();
+		const sig = await signAction('archive', 'email-1', 'mailbox-1', exp, OTHER_KEY);
+
+		await expect(verifyAction('archive', 'email-1', 'mailbox-1', exp, sig, KEY)).resolves.toBe(false);
+	});
+
+	it('rejects an expired signature even when otherwise valid', async () => {
+		const pastExp = Math.floor(Date.now() / 1000) - 1;
+		const sig = await signAction('archive', 'email-1', 'mailbox-1', pastExp, KEY);
+
+		await expect(verifyAction('archive', 'email-1', 'mailbox-1', pastExp, sig, KEY)).resolves.toBe(false);
+	});
+
+	it('rejects malformed signatures without throwing', async () => {
+		const exp = futureExp();
+
+		// Empty, wrong length, and non-hex input all previously risked reaching
+		// hexToBuffer and producing NaN bytes.
+		await expect(verifyAction('archive', 'e', 'm', exp, '', KEY)).resolves.toBe(false);
+		await expect(verifyAction('archive', 'e', 'm', exp, 'abc', KEY)).resolves.toBe(false);
+		await expect(verifyAction('archive', 'e', 'm', exp, 'z'.repeat(64), KEY)).resolves.toBe(false);
+	});
+
+	it('rejects a signature that is a valid HMAC of a different payload', async () => {
+		const exp = futureExp();
+		// The old implementation compared against a self-verified digest; make
+		// sure a well-formed signature for another payload is still refused.
+		const sig = await signAction('archive', 'other-email', 'mailbox-1', exp, KEY);
+
+		await expect(verifyAction('archive', 'email-1', 'mailbox-1', exp, sig, KEY)).resolves.toBe(false);
+	});
+});

--- a/test/oauth-handler.test.ts
+++ b/test/oauth-handler.test.ts
@@ -158,4 +158,61 @@ describe('handleAuthorize — redirect_uri allowlist + PKCE enforcement', () => 
 
 		expect(response.status).toBe(302);
 	});
+
+	// RFC 8252 §7.3: a REGISTERED client's loopback callback must still match
+	// when the runtime port differs, since native clients bind ephemeral ports.
+	// This is exactly how the fastmail CLI behaves: it registers a portless
+	// loopback URI, then authorizes on whatever port it got.
+	describe('registered-client loopback matching ignores the port', () => {
+		function makeRegisteredEnv(registeredUris: string[]) {
+			const kv = {
+				get: vi.fn(async (key: string) =>
+					key.startsWith('client:')
+						? JSON.stringify({ client_id: 'cli', client_name: 'cli', redirect_uris: registeredUris })
+						: null
+				),
+				put: vi.fn(async () => undefined),
+				delete: vi.fn(async () => undefined),
+			};
+			return {
+				OAUTH_KV: kv,
+				ACCESS_TEAM_NAME: TEAM_NAME,
+				ACCESS_CLIENT_ID: CLIENT_ID,
+			} as unknown as Env;
+		}
+
+		it.each([
+			['IPv4', 'http://127.0.0.1/callback', 'http://127.0.0.1:53187/callback'],
+			['localhost', 'http://localhost/callback', 'http://localhost:53187/callback'],
+			['IPv6', 'http://[::1]/callback', 'http://[::1]:53187/callback'],
+		])('allows a %s loopback callback on a different port', async (_label, registered, requested) => {
+			const env = makeRegisteredEnv([registered]);
+			const { request, url } = authorizeRequest({
+				client_id: 'cli',
+				redirect_uri: requested,
+				response_type: 'code',
+				code_challenge: 'a'.repeat(43),
+				code_challenge_method: 'S256',
+			});
+
+			const response = await handleAuthorize(request, env, url);
+
+			expect(response.status).toBe(302);
+		});
+
+		it('still rejects a loopback callback whose path differs from the registered one', async () => {
+			const env = makeRegisteredEnv(['http://127.0.0.1/callback']);
+			const { request, url } = authorizeRequest({
+				client_id: 'cli',
+				redirect_uri: 'http://127.0.0.1:53187/evil',
+				response_type: 'code',
+				code_challenge: 'a'.repeat(43),
+				code_challenge_method: 'S256',
+			});
+
+			const response = await handleAuthorize(request, env, url);
+
+			expect(response.status).toBe(400);
+		});
+	});
 });

--- a/test/oauth-handler.test.ts
+++ b/test/oauth-handler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { handleGetTokenCallback } from '../src/oauth-handler';
+import { handleGetTokenCallback, handleAuthorize } from '../src/oauth-handler';
 
 const TEAM_NAME = 'example-team';
 const CLIENT_ID = 'access-client-id';
@@ -53,5 +53,109 @@ describe('handleGetTokenCallback', () => {
 		expect(response.status).toBe(400);
 		expect(await response.text()).toContain('unsupported alg');
 		expect(kv.put).not.toHaveBeenCalled();
+	});
+});
+
+describe('handleAuthorize — redirect_uri allowlist + PKCE enforcement', () => {
+	// KV with no registered client (the unregistered-client_id attack path).
+	function makeEnv() {
+		const kv = {
+			get: vi.fn(async () => null),
+			put: vi.fn(async () => undefined),
+			delete: vi.fn(async () => undefined),
+		};
+		const env = {
+			OAUTH_KV: kv,
+			ACCESS_TEAM_NAME: TEAM_NAME,
+			ACCESS_CLIENT_ID: CLIENT_ID,
+		} as unknown as Env;
+		return { env, kv };
+	}
+
+	function authorizeRequest(params: Record<string, string>) {
+		const url = new URL('https://worker.example/mcp/authorize');
+		for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+		return { request: new Request(url.toString()), url };
+	}
+
+	it('rejects an attacker-controlled redirect_uri for an unregistered client (the exploit)', async () => {
+		const { env, kv } = makeEnv();
+		const { request, url } = authorizeRequest({
+			client_id: 'attacker-random-id',
+			redirect_uri: 'https://evil.example/cb',
+			response_type: 'code',
+			code_challenge: 'a'.repeat(43),
+			code_challenge_method: 'S256',
+		});
+
+		const response = await handleAuthorize(request, env, url);
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain('Invalid redirect_uri');
+		// No state persisted — the flow never reached the CF Access redirect.
+		expect(kv.put).not.toHaveBeenCalled();
+	});
+
+	it('rejects a non-OOB authorize request with no PKCE challenge', async () => {
+		const { env, kv } = makeEnv();
+		const { request, url } = authorizeRequest({
+			client_id: 'some-client',
+			redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+			response_type: 'code',
+		});
+
+		const response = await handleAuthorize(request, env, url);
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain('PKCE');
+		expect(kv.put).not.toHaveBeenCalled();
+	});
+
+	it('rejects a plain PKCE method (downgrade attempt)', async () => {
+		const { env } = makeEnv();
+		const { request, url } = authorizeRequest({
+			client_id: 'some-client',
+			redirect_uri: 'https://claude.ai/cb',
+			response_type: 'code',
+			code_challenge: 'verifier-as-challenge',
+			code_challenge_method: 'plain',
+		});
+
+		const response = await handleAuthorize(request, env, url);
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain('S256');
+	});
+
+	it('accepts an allowlisted https redirect with S256 PKCE and 302s to CF Access', async () => {
+		const { env, kv } = makeEnv();
+		const { request, url } = authorizeRequest({
+			client_id: 'some-client',
+			redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+			response_type: 'code',
+			code_challenge: 'a'.repeat(43),
+			code_challenge_method: 'S256',
+		});
+
+		const response = await handleAuthorize(request, env, url);
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get('Location')).toContain('cloudflareaccess.com');
+		expect(kv.put).toHaveBeenCalledOnce();
+	});
+
+	it('accepts a loopback redirect on an ephemeral port with S256 PKCE', async () => {
+		const { env } = makeEnv();
+		const { request, url } = authorizeRequest({
+			client_id: 'cli-client',
+			redirect_uri: 'http://127.0.0.1:53187/callback',
+			response_type: 'code',
+			code_challenge: 'a'.repeat(43),
+			code_challenge_method: 'S256',
+		});
+
+		const response = await handleAuthorize(request, env, url);
+
+		expect(response.status).toBe(302);
 	});
 });

--- a/test/oauth-utils.test.ts
+++ b/test/oauth-utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { verifyAccessIdToken } from '../src/oauth-utils';
+import { verifyAccessIdToken, isAllowedRedirectUri } from '../src/oauth-utils';
 
 const TEAM_NAME = 'example-team';
 const CLIENT_ID = 'access-client-id';
@@ -126,5 +126,56 @@ describe('verifyAccessIdToken', () => {
 		await expect(
 			verifyAccessIdToken(token, { teamName: TEAM_NAME, clientId: CLIENT_ID, now: NOW })
 		).rejects.toThrow('audience mismatch');
+	});
+});
+
+describe('isAllowedRedirectUri', () => {
+	const ORIGIN = 'https://worker.example';
+
+	it('rejects an arbitrary external https origin (the phishing vector)', () => {
+		expect(isAllowedRedirectUri('https://evil.example/cb', ORIGIN)).toBe(false);
+	});
+
+	it('allows the default Claude/Anthropic hosts and their subdomains', () => {
+		expect(isAllowedRedirectUri('https://claude.ai/api/mcp/auth_callback', ORIGIN)).toBe(true);
+		expect(isAllowedRedirectUri('https://claude.com/cb', ORIGIN)).toBe(true);
+		expect(isAllowedRedirectUri('https://console.anthropic.com/cb', ORIGIN)).toBe(true);
+	});
+
+	it("does not treat an attacker suffix domain as a subdomain match", () => {
+		expect(isAllowedRedirectUri('https://claude.ai.evil.example/cb', ORIGIN)).toBe(false);
+		expect(isAllowedRedirectUri('https://notclaude.ai/cb', ORIGIN)).toBe(false);
+	});
+
+	it('allows loopback on any port for native/CLI clients', () => {
+		expect(isAllowedRedirectUri('http://127.0.0.1:53187/callback', ORIGIN)).toBe(true);
+		expect(isAllowedRedirectUri('http://localhost:8080/callback', ORIGIN)).toBe(true);
+	});
+
+	it("allows the worker's own origin", () => {
+		expect(isAllowedRedirectUri('https://worker.example/mcp/callback', ORIGIN)).toBe(true);
+	});
+
+	it('allows OOB redirect targets', () => {
+		expect(isAllowedRedirectUri('urn:ietf:wg:oauth:2.0:oob', ORIGIN)).toBe(true);
+		expect(isAllowedRedirectUri('oob:custom', ORIGIN)).toBe(true);
+	});
+
+	it('rejects non-loopback plain http and custom app schemes', () => {
+		expect(isAllowedRedirectUri('http://claude.ai/cb', ORIGIN)).toBe(false);
+		expect(isAllowedRedirectUri('com.evil.app://cb', ORIGIN)).toBe(false);
+	});
+
+	it('honors an explicit ALLOWED_REDIRECT_HOSTS override, replacing the defaults', () => {
+		const allow = 'partner.example';
+		expect(isAllowedRedirectUri('https://partner.example/cb', ORIGIN, allow)).toBe(true);
+		expect(isAllowedRedirectUri('https://app.partner.example/cb', ORIGIN, allow)).toBe(true);
+		// Once an override is set, the built-in Claude defaults no longer apply.
+		expect(isAllowedRedirectUri('https://claude.ai/cb', ORIGIN, allow)).toBe(false);
+	});
+
+	it('rejects malformed redirect URIs', () => {
+		expect(isAllowedRedirectUri('not a url', ORIGIN)).toBe(false);
+		expect(isAllowedRedirectUri('', ORIGIN)).toBe(false);
 	});
 });

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
 	type PermissionsConfig,
 	type UserConfig,
 	getUserConfig,
+	getPermissionsConfig,
 	isToolAllowed,
 	getVisibleTools,
 	checkMcpPermissions,
@@ -285,6 +286,67 @@ describe('checkMcpPermissions — fail-closed', () => {
 		});
 		const result = await checkMcpPermissions(body, 'delegate@example.com', mockKv);
 		expect(result).toBeNull();
+	});
+});
+
+describe('getPermissionsConfig — fail-closed defaults', () => {
+	beforeEach(() => {
+		_resetCache();
+	});
+
+	it('defaults to delegate when config:permissions is absent from KV', async () => {
+		const kv = { get: vi.fn(async () => null) } as unknown as KVNamespace;
+
+		const config = await getPermissionsConfig(kv);
+
+		expect(config.default_role).toBe('delegate');
+		expect(config.users).toEqual({});
+		// An identity with no explicit entry must NOT inherit admin.
+		expect(getUserConfig(config, 'someone@example.com').role).toBe('delegate');
+	});
+
+	it('does not grant send rights to an unlisted user under the default config', async () => {
+		const kv = { get: vi.fn(async () => null) } as unknown as KVNamespace;
+
+		const config = await getPermissionsConfig(kv);
+		const user = getUserConfig(config, 'unlisted@example.com');
+
+		expect(isToolAllowed(user, 'send_email').allowed).toBe(false);
+		expect(isToolAllowed(user, 'delete_email').allowed).toBe(true); // INBOX_MANAGE is delegate-allowed
+		expect(isToolAllowed(user, 'list_emails').allowed).toBe(true);
+	});
+
+	it('fails closed on a KV read error without caching the fallback', async () => {
+		const get = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('KV unavailable'))
+			.mockResolvedValueOnce({
+				users: { 'omar@example.com': { role: 'admin', disabled_categories: [] } },
+				default_role: 'delegate',
+				default_disabled_categories: [],
+			});
+		const kv = { get } as unknown as KVNamespace;
+
+		// First call fails → fail-closed default.
+		const failed = await getPermissionsConfig(kv);
+		expect(failed.default_role).toBe('delegate');
+		expect(failed.users).toEqual({});
+
+		// A transient failure must not be cached for the 5-minute window: the
+		// very next call re-reads KV and picks up the real config.
+		const recovered = await getPermissionsConfig(kv);
+		expect(getUserConfig(recovered, 'omar@example.com').role).toBe('admin');
+		expect(get).toHaveBeenCalledTimes(2);
+	});
+
+	it('caches a genuine miss (does not re-read KV on every call)', async () => {
+		const get = vi.fn(async () => null);
+		const kv = { get } as unknown as KVNamespace;
+
+		await getPermissionsConfig(kv);
+		await getPermissionsConfig(kv);
+
+		expect(get).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/wrangler.jsonc.example
+++ b/wrangler.jsonc.example
@@ -6,8 +6,12 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "fastmail-mcp-remote",
 	"account_id": "<your-cloudflare-account-id>",
-	"workers_dev": true,
-	"preview_urls": true,
+	// Serve ONLY via the custom domain below. Leaving these on also exposes
+	// <worker>.<account>.workers.dev and per-version preview URLs, which bypass
+	// any edge protection (WAF, rate limiting, hostname-scoped Access) bound to
+	// the custom hostname. Set them to true only if you have no custom domain.
+	"workers_dev": false,
+	"preview_urls": false,
 	"routes": [
 		{
 			"pattern": "<your-custom-domain>",


### PR DESCRIPTION
Closes #49, #50, #51, #52, #53, #54 — every finding from the 2026-07-20 security audit.

## #49 (HIGH) — OAuth `redirect_uri` phishing → full-scope admin mailbox token

The headline fix. `handleAuthorize` accepted **any** `https://` `redirect_uri` when the `client_id` had no registration record, and PKCE was optional at the token endpoint. So a phishing link could bounce a real login's auth code to an attacker-controlled origin, and the attacker could redeem it — no `code_verifier` required — for a 30-day sliding-window token with full read/send/delete of the mailbox.

- New `isAllowedRedirectUri()` enforced for **all** clients, registered or not. Permits loopback (any port), the worker's own origin, and `https` on an allowlisted host (default `claude.ai` / `claude.com` / `anthropic.com`, overridable via `ALLOWED_REDIRECT_HOSTS`). The unregistered→any-https fallback is deleted.
- Enforced at **three** points: authorize, token (re-checked against the code-bound URI), and `/register` — so unauthenticated registration can no longer stage a phishing target.
- **PKCE `S256` now required** for every non-OOB flow. `plain` is rejected at authorize and token, and removed from discovery metadata.

**Compatibility:** the `fastmail` CLI registers `http://127.0.0.1/callback` but authorizes on an ephemeral port, so a naive exact-match check would have broken it. `redirectUriMatchesRegistered()` preserves RFC 8252 §7.3 port-agnostic loopback matching. Verified the CLI's flow (S256 + loopback) still passes.

## #50 (MEDIUM) — fail-open default role

`DEFAULT_CONFIG.default_role` was `'admin'`, so a missing, deleted, or never-seeded `config:permissions` key silently promoted **every** allowed identity to full send/delete. Now defaults to `'delegate'`, and a KV **read failure** is distinguished from a KV **miss** — a transient blip is no longer cached as the fallback for the full 5-minute window.

Verified production KV already has explicit entries for both users (`omar@shahine.com` = admin, `lobster@shahine.com` = delegate), so **nobody is downgraded** by this change.

## #51 (MEDIUM) — TTL-less client records

`/register` is unauthenticated and wrote permanent `client:{id}` keys, so a script could grow KV without bound. Now bounded at 90 days; clients re-register transparently once a record lapses.

## #52 (MEDIUM) — `workers_dev` / `preview_urls`

Both set to `false` so the worker serves only via the custom domain instead of also at `*.workers.dev` and per-version preview URLs, which bypass edge protection bound to the custom hostname. Confirmed the CLI and all docs use `fastmail-mcp.shahine.com`, and nothing references `workers.dev`.

⚠️ **`wrangler.jsonc` is gitignored**, so this PR only carries the change in `wrangler.jsonc.example`. The local config was updated too, but the production change takes effect on the next `npm run deploy`.

## #53 (LOW) — security headers on served HTML

The OOB, token-success, and error pages now send `Referrer-Policy: no-referrer` (so a bearer token can't leak via `Referer`), a deny-by-default CSP with no `connect`/`form`/`frame` surface, `nosniff`, and `X-Frame-Options: DENY`. Inline `onclick` handlers were converted to nonce'd `addEventListener` calls, so the CSP needs no `'unsafe-inline'` for scripts.

## #54 (LOW) — misc hardening

- **`verifyAction` HMAC compare.** The old code signed the payload, called `crypto.subtle.verify` on that digest *against itself*, threw the result away, and decided with a short-circuiting `sig === bufferToHex(expected)` — the "constant-time" comment was false. It now verifies the **caller's** signature against the payload via `crypto.subtle.verify`, which compares internally in constant time. Malformed hex is rejected up front.
- **Datamarking token** uses `crypto.getRandomValues` instead of `Math.random()`.
- **`/api/action/*` CORS** origin is now configurable via `ACTION_ALLOWED_ORIGINS`. It still defaults to `*` — these endpoints carry no ambient credentials (the capability *is* the signed single-use URL), and the reading-digest page has a local `file://` mode that sends `Origin: null`, so hardcoding an origin would break it for no security gain.

## Verification

- `npm run type-check` — clean
- `npm run test` — **84 pass, 25 new**, covering the redirect allowlist (including the `claude.ai.evil.example` suffix-spoof), the authorize-endpoint exploit path returning 400, HMAC round-trip plus forgery/tamper/expiry rejection, and the fail-closed permissions defaults
- `wrangler deploy --dry-run` — builds and binds cleanly

## Note for review

Two follow-ups deliberately **not** done here:
1. The stored KV config still has `"default_role":"admin"`. It's inert today (both users have explicit entries) but should be flipped to `delegate` for defense in depth — that's a production data change, not a code change, so I left it out of the PR.
2. #42 (route `/mcp` back through the Durable Object) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
