### PR TITLE
docs: document ALLOWED_REDIRECT_HOSTS and add missing vars block to example

### DIFF
--- a/wrangler.jsonc.example
+++ b/wrangler.jsonc.example
@@ -53,6 +53,19 @@
 	"observability": {
 		"enabled": true
 	},
+	// Plaintext vars. Keep this block even if you set vars in the dashboard —
+	// deploying without it WIPES all dashboard-set plaintext vars.
+	"vars": {
+		"ACCESS_TEAM_NAME": "<your-zero-trust-team-name>",
+		"ALLOWED_USERS": "<comma-separated-allowed-emails>",
+		// Optional. Extra hosts allowed as OAuth redirect_uri targets. This
+		// REPLACES the built-in default (claude.ai,claude.com,anthropic.com)
+		// rather than adding to it, so re-list those if you set it. Loopback
+		// and the worker's own origin are always allowed regardless.
+		// Add a host here for any non-Claude MCP client (e.g. chatgpt.com),
+		// otherwise its OAuth flow fails with "Invalid redirect_uri".
+		"ALLOWED_REDIRECT_HOSTS": "claude.ai,claude.com,anthropic.com"
+	},
 	"dev": {
 		"port": 8788
 	}


### PR DESCRIPTION
Follow-up to #55.

`wrangler.jsonc.example` had **no `vars` block at all**, even though `AGENTS.md` warns that deploying without one wipes every dashboard-set plaintext var. Anyone using the example to bootstrap a deploy would hit precisely that footgun.

Adds the block with placeholders and documents `ALLOWED_REDIRECT_HOSTS` (introduced in #55), including the sharp edge: setting it **replaces** the built-in `claude.ai,claude.com,anthropic.com` default instead of extending it. A non-Claude MCP client must therefore be listed explicitly.

That edge is not hypothetical — an active ChatGPT connector (registered 2026-07-19, token valid to 08-18) would have silently failed on its next re-authorization. Production now runs `claude.ai,claude.com,anthropic.com,chatgpt.com`; verified live that chatgpt.com is allowed while `chatgpt.com.evil.example`, `notchatgpt.com`, plain-http `chatgpt.com`, and `cursor://` are all still rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)