### PR TITLE
security: require registered clients for non-OOB authorize

### DIFF
--- a/src/oauth-handler.ts
+++ b/src/oauth-handler.ts
@@ -138,25 +138,53 @@ export async function handleAuthorize(request: Request, env: Env, url: URL): Pro
 	if (!isAllowedRedirectUri(redirectUri, url.origin, env.ALLOWED_REDIRECT_HOSTS)) {
 		return new Response('Invalid redirect_uri', { status: 400 });
 	}
-	if (!isOOBUri) {
-		// For a pre-registered client, additionally require membership in its
-		// registered redirect_uris. Loopback URIs match on scheme+host+path but
-		// ignore the port, because native/CLI clients bind an ephemeral port at
-		// runtime that differs from the one registered (RFC 8252 §7.3).
-		const clientJson = await env.OAUTH_KV.get(`client:${clientId}`);
-		if (clientJson) {
-			const clientData = JSON.parse(clientJson) as OAuthClientData;
-			if (!redirectUriMatchesRegistered(redirectUri, clientData.redirect_uris)) {
-				return new Response('Invalid redirect_uri', { status: 400 });
-			}
-		}
-	}
-
 	// Require PKCE (S256) for every non-OOB flow. Without this, an intercepted
 	// authorization code alone is enough to mint a full-scope token. OOB is
 	// exempt because its code is shown on-screen and never auto-redirected.
+	//
+	// Checked before the client lookup below so a malformed request gets the
+	// accurate error and costs no KV read.
 	if (!isOOBUri && (!codeChallenge || codeChallengeMethod !== 'S256')) {
 		return new Response('PKCE (code_challenge with S256) is required for non-OOB flows', { status: 400 });
+	}
+
+	if (!isOOBUri) {
+		// The client MUST be pre-registered, and the redirect_uri must match one
+		// of its registered values. RFC 9700 §2.1 requires exact string matching
+		// for redirect URIs: the host allowlist above is *pattern* matching, so
+		// an open redirect on an allowlisted host (e.g. claude.ai) would other-
+		// wise be enough to bounce an auth code to an attacker. Requiring
+		// registration is what makes the match exact.
+		//
+		// Loopback URIs still match on scheme+host+path while ignoring the port,
+		// because native/CLI clients bind an ephemeral port at runtime that
+		// differs from the one registered (RFC 8252 §7.3).
+		//
+		// OOB is exempt: its code is displayed on-screen and never redirected,
+		// so there is no redirect target to match.
+		const clientJson = await env.OAUTH_KV.get(`client:${clientId}`);
+		if (!clientJson) {
+			return new Response('Unknown client_id — dynamic client registration is required', {
+				status: 400,
+			});
+		}
+		const clientData = JSON.parse(clientJson) as OAuthClientData;
+		if (!redirectUriMatchesRegistered(redirectUri, clientData.redirect_uris)) {
+			return new Response('Invalid redirect_uri', { status: 400 });
+		}
+
+		// Sliding window: refresh the registration TTL on each successful use.
+		// CLIENT_TTL_SECONDS is a hard KV expiry, so without this an actively
+		// used client would lapse after 90 days and then hard-fail with
+		// "Unknown client_id" (previously it degraded to the host allowlist and
+		// kept working). Best-effort — never blocks the auth flow.
+		try {
+			await env.OAUTH_KV.put(`client:${clientId}`, clientJson, {
+				expirationTtl: CLIENT_TTL_SECONDS,
+			});
+		} catch (e) {
+			console.warn(`[oauth] client TTL refresh failed (non-fatal): ${e}`);
+		}
 	}
 
 	// Generate state and store OAuth parameters in KV

--- a/test/oauth-handler.test.ts
+++ b/test/oauth-handler.test.ts
@@ -72,6 +72,25 @@ describe('handleAuthorize — redirect_uri allowlist + PKCE enforcement', () => 
 		return { env, kv };
 	}
 
+	// KV holding a registered client with the given redirect_uris.
+	function makeRegisteredEnv(registeredUris: string[]) {
+		const kv = {
+			get: vi.fn(async (key: string) =>
+				key.startsWith('client:')
+					? JSON.stringify({ client_id: 'cli', client_name: 'cli', redirect_uris: registeredUris })
+					: null
+			),
+			put: vi.fn(async () => undefined),
+			delete: vi.fn(async () => undefined),
+		};
+		const env = {
+			OAUTH_KV: kv,
+			ACCESS_TEAM_NAME: TEAM_NAME,
+			ACCESS_CLIENT_ID: CLIENT_ID,
+		} as unknown as Env;
+		return { env, kv };
+	}
+
 	function authorizeRequest(params: Record<string, string>) {
 		const url = new URL('https://worker.example/mcp/authorize');
 		for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
@@ -127,8 +146,30 @@ describe('handleAuthorize — redirect_uri allowlist + PKCE enforcement', () => 
 		expect(await response.text()).toContain('S256');
 	});
 
-	it('accepts an allowlisted https redirect with S256 PKCE and 302s to CF Access', async () => {
+	// RFC 9700 §2.1 requires exact redirect_uri matching, which is only possible
+	// against a registered client. An allowlisted host alone is pattern matching
+	// (an open redirect on claude.ai would bounce the code onward), so an
+	// unregistered client_id is refused outright.
+	it('rejects an otherwise-valid request from an unregistered client', async () => {
 		const { env, kv } = makeEnv();
+		const { request, url } = authorizeRequest({
+			client_id: 'never-registered',
+			redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+			response_type: 'code',
+			code_challenge: 'a'.repeat(43),
+			code_challenge_method: 'S256',
+		});
+
+		const response = await handleAuthorize(request, env, url);
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain('dynamic client registration is required');
+		// No state persisted — the flow never reached the CF Access redirect.
+		expect(kv.put).not.toHaveBeenCalled();
+	});
+
+	it('accepts an allowlisted https redirect with S256 PKCE and 302s to CF Access', async () => {
+		const { env, kv } = makeRegisteredEnv(['https://claude.ai/api/mcp/auth_callback']);
 		const { request, url } = authorizeRequest({
 			client_id: 'some-client',
 			redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
@@ -141,11 +182,12 @@ describe('handleAuthorize — redirect_uri allowlist + PKCE enforcement', () => 
 
 		expect(response.status).toBe(302);
 		expect(response.headers.get('Location')).toContain('cloudflareaccess.com');
-		expect(kv.put).toHaveBeenCalledOnce();
+		// Two writes: the state row, plus the sliding-window client TTL refresh.
+		expect(kv.put).toHaveBeenCalledTimes(2);
 	});
 
 	it('accepts a loopback redirect on an ephemeral port with S256 PKCE', async () => {
-		const { env } = makeEnv();
+		const { env } = makeRegisteredEnv(['http://127.0.0.1/callback']);
 		const { request, url } = authorizeRequest({
 			client_id: 'cli-client',
 			redirect_uri: 'http://127.0.0.1:53187/callback',
@@ -164,29 +206,12 @@ describe('handleAuthorize — redirect_uri allowlist + PKCE enforcement', () => 
 	// This is exactly how the fastmail CLI behaves: it registers a portless
 	// loopback URI, then authorizes on whatever port it got.
 	describe('registered-client loopback matching ignores the port', () => {
-		function makeRegisteredEnv(registeredUris: string[]) {
-			const kv = {
-				get: vi.fn(async (key: string) =>
-					key.startsWith('client:')
-						? JSON.stringify({ client_id: 'cli', client_name: 'cli', redirect_uris: registeredUris })
-						: null
-				),
-				put: vi.fn(async () => undefined),
-				delete: vi.fn(async () => undefined),
-			};
-			return {
-				OAUTH_KV: kv,
-				ACCESS_TEAM_NAME: TEAM_NAME,
-				ACCESS_CLIENT_ID: CLIENT_ID,
-			} as unknown as Env;
-		}
-
 		it.each([
 			['IPv4', 'http://127.0.0.1/callback', 'http://127.0.0.1:53187/callback'],
 			['localhost', 'http://localhost/callback', 'http://localhost:53187/callback'],
 			['IPv6', 'http://[::1]/callback', 'http://[::1]:53187/callback'],
 		])('allows a %s loopback callback on a different port', async (_label, registered, requested) => {
-			const env = makeRegisteredEnv([registered]);
+			const { env } = makeRegisteredEnv([registered]);
 			const { request, url } = authorizeRequest({
 				client_id: 'cli',
 				redirect_uri: requested,
@@ -201,7 +226,7 @@ describe('handleAuthorize — redirect_uri allowlist + PKCE enforcement', () => 
 		});
 
 		it('still rejects a loopback callback whose path differs from the registered one', async () => {
-			const env = makeRegisteredEnv(['http://127.0.0.1/callback']);
+			const { env } = makeRegisteredEnv(['http://127.0.0.1/callback']);
 			const { request, url } = authorizeRequest({
 				client_id: 'cli',
 				redirect_uri: 'http://127.0.0.1:53187/evil',


### PR DESCRIPTION
## Why

An unregistered `client_id` previously fell through to **host-allowlist-only** `redirect_uri` validation. That allowlist is *pattern* matching (`host === h || host.endsWith('.' + h)`), but [RFC 9700 §2.1](https://datatracker.ietf.org/doc/html/rfc9700) requires **exact string matching** for redirect URIs.

The gap that leaves: an open redirect on an allowlisted host (e.g. `claude.ai`) would have been enough to bounce an auth code to an attacker — reopening the phishing chain that #49 closed, just one hop further out. Requiring a pre-registered client is what makes the match exact. The host allowlist stays at `/register` as defense in depth.

This also aligns this worker with travel-hub, which already requires registration. Consistency matters here: three workers sharing one OAuth lineage but three dialects means fixes don't port cleanly between them.

## Changes

- **Require a registered client** for non-OOB `/mcp/authorize`. Unregistered → `400 Unknown client_id — dynamic client registration is required`.
- **Sliding-window TTL refresh** on the client record at authorize. `CLIENT_TTL_SECONDS` is a hard 90-day KV expiry, so without this an actively-used client would lapse and then hard-fail (previously it silently degraded to the allowlist and kept working).
- **PKCE S256 check moved above the client lookup**, so malformed requests get the accurate error and cost no KV read.

OOB is exempt throughout — its code is displayed on-screen and never redirected, so there is no redirect target to match. Loopback still ignores the port per RFC 8252 §7.3.

## Compatibility

Low risk, verified rather than assumed:
- **Existing tokens unaffected** — validated directly against `mcp_oauth`/KV, no client lookup.
- **The fastmail CLI already does DCR** (`cli/auth.ts:214`), and Claude connectors register automatically.

## Verification

`npm test` → **95 pass** (added a test for the new control; updated two that asserted the old unregistered-allowed contract).

Live post-deploy:
| Case | Result |
|---|---|
| Unregistered client, otherwise valid | `400` registration required |
| No PKCE | accurate `PKCE ... required` (not "unknown client") |
| Register → authorize | `302` → CF Access |
| Live MCP still serving | ✅ 59 mailboxes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)